### PR TITLE
Add install for microk8s

### DIFF
--- a/install/cri-containerd-microk8s.yaml
+++ b/install/cri-containerd-microk8s.yaml
@@ -100,12 +100,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-            - mountPath: /var/lib/kubelet/pods
+            - mountPath: /var/snap/microk8s/common/var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
             - mountPath: /run/containerd/containerd.sock
               name: runtime-socket
-            - mountPath: /var/lib/containerd
+            - mountPath: /var/snap/microk8s/common/var/lib/containerd
               name: snapshot-home
       volumes:
         - hostPath:

--- a/install/cri-containerd-microk8s.yaml
+++ b/install/cri-containerd-microk8s.yaml
@@ -1,0 +1,130 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-image.warm-metal.tech
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-image-warm-metal
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-image-warm-metal
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-image-warm-metal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-image-warm-metal
+subjects:
+  - kind: ServiceAccount
+    name: csi-image-warm-metal
+    namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-image-warm-metal
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-image-warm-metal
+  template:
+    metadata:
+      labels:
+        app: csi-image-warm-metal
+    spec:
+      hostNetwork: true
+      serviceAccountName: csi-image-warm-metal
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock"]
+          args:
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/snap/microk8s/common/var/lib/kubelet/plugins/csi-image.warm-metal.tech/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+        - name: plugin
+          image: warmmetal/csi-image:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-endpoint=$(CSI_ENDPOINT)"
+            - "-node=$(KUBE_NODE_NAME)"
+            - "-containerd-addr=$(CONTAINERD_ADDRESS)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CONTAINERD_ADDRESS
+              value: unix:///run/containerd/containerd.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /run/containerd/containerd.sock
+              name: runtime-socket
+            - mountPath: /var/lib/containerd
+              name: snapshot-home
+      volumes:
+        - hostPath:
+            path: /var/snap/microk8s/common/var/lib/kubelet/plugins/csi-image.warm-metal.tech
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/snap/microk8s/common/var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/snap/microk8s/common/var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /var/snap/microk8s/common/var/lib/containerd
+            type: Directory
+          name: snapshot-home
+        - hostPath:
+            path: /var/snap/microk8s/common/run/containerd.sock
+            type: Socket
+          name: runtime-socket


### PR DESCRIPTION
Testing with microk8s in a VM. 

Setup with the modified installation in this PR:
```
microk8s install
multipass exec microk8s-vm -- sudo /snap/bin/microk8s.config  > ~/.kube/microk8s-vm.yaml
export KUBECONFIG=~/.kube/microk8s-vm.yaml
kubectl apply -f install/cri-containerd-microk8s.yaml
kubectl apply -f test/integration/manifests/ephemeral-volume.yaml
```

```
k version
Client Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.4-dirty", GitCommit:"e87da0bd6e03ec3fea7933c4b5263d151aafd07c", GitTreeState:"dirty", BuildDate:"2021-03-15T10:03:32Z", GoVersion:"go1.16.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.5-34+40f5951bd9888a", GitCommit:"40f5951bd9888a0e27960e88d1250627fb085871", GitTreeState:"clean", BuildDate:"2021-03-22T16:59:52Z", GoVersion:"go1.15.10", Compiler:"gc", Platform:"linux/amd64"}
```

Microk8s uses containerd:
```
root      2864  1.7  2.4 1787136 98016 ?       Ssl  16:29   0:32 /snap/microk8s/2094/kubelet --kubeconfig=/var/snap/microk8s/2094/credentials/kubelet.config --cert-dir=/var/snap/microk8s/2094/certs --client-ca-file=/var/snap/microk8s/2094/certs/ca.crt --anonymous-auth=false --network-plugin=cni --root-dir=/var/snap/microk8s/common/var/lib/kubelet --fail-swap-on=false --cni-conf-dir=/var/snap/microk8s/2094/args/cni-network/ --cni-bin-dir=/var/snap/microk8s/2094/opt/cni/bin/ --feature-gates=DevicePlugins=true --eviction-hard=memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi --container-runtime=remote --container-runtime-endpoint=/var/snap/microk8s/common/run/containerd.sock --containerd=/var/snap/microk8s/common/run/containerd.sock --node-labels=microk8s.io/cluster=true --authentication-token-webhook=true

```

Logs from the daemon pod:

```
 plugin I0406 00:03:51.425789       1 node.go:34] request: volume_id:"csi-1c19d0996f472b52aa61fa8be90a7d1e3a297a518d68d03a9ca002953bf32530" target_path:"/var/snap/microk8s/common/var/lib/kubelet/pods/9b3755f5-9e50-4f30-b4db-3ff256fd3ffd/volumes/kubernete 
 s.io~csi/target/mount" volume_capability:<mount:<> access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:"csi.storage.k8s.io/ephemeral" value:"true" > volume_context:<key:"csi.storage.k8s.io/pod.name" value:"ephemeral-volume-sxwb4" > volume_conte 
 xt:<key:"csi.storage.k8s.io/pod.namespace" value:"default" > volume_context:<key:"csi.storage.k8s.io/pod.uid" value:"9b3755f5-9e50-4f30-b4db-3ff256fd3ffd" > volume_context:<key:"csi.storage.k8s.io/serviceAccount.name" value:"default" > volume_context:<k 
 ey:"image" value:"docker.io/warmmetal/csi-image-test:simple-fs" >                                                                                                                                                                                             
 plugin I0406 00:03:51.447878       1 mounter.go:117] image docker.io/warmmetal/csi-image-test:simple-fs unpacked                                                                                                                                              
 plugin I0406 00:03:51.450597       1 mounter.go:136] prepare sha256:07fb94c730eb52c6718a45978209e1249617058da234cd270f4bd587c7ddda87                                                                                                                          
 plugin E0406 00:03:51.460421       1 mounter.go:254] fail to mount image docker.io/warmmetal/csi-image-test:simple-fs to /var/snap/microk8s/common/var/lib/kubelet/pods/9b3755f5-9e50-4f30-b4db-3ff256fd3ffd/volumes/kubernetes.io~csi/target/mount: no such  
 file or directory                                                                                                                                                                                                                                             
 plugin E0406 00:03:51.460463       1 mounter.go:245] found error no such file or directory. Prepare removing the snapshot just created                                                                                                                        
 plugin I0406 00:03:51.462693       1 mounter.go:222] found snapshot csi-image.warm-metal.tech-sha256:07fb94c730eb52c6718a45978209e1249617058da234cd270f4bd587c7ddda87 for volume csi-1c19d0996f472b52aa61fa8be90a7d1e3a297a518d68d03a9ca002953bf32530. prepar 
 e to unref it.                                                                                                                                                                                                                                                
 plugin I0406 00:03:51.462750       1 mounter.go:178] unref snapshot csi-image.warm-metal.tech-sha256:07fb94c730eb52c6718a45978209e1249617058da234cd270f4bd587c7ddda87, parent sha256:07fb94c730eb52c6718a45978209e1249617058da234cd270f4bd587c7ddda87         
 plugin I0406 00:03:51.462760       1 mounter.go:190] no other mount refs snapshot csi-image.warm-metal.tech-sha256:07fb94c730eb52c6718a45978209e1249617058da234cd270f4bd587c7ddda87, remove it                                                                
 plugin E0406 00:03:51.468839       1 utils.go:101] GRPC error: rpc error: code = Internal desc = no such file or directory 
```

```
root@microk8s-vm:/home/ubuntu# tree /var/snap/microk8s/common/var/lib/kubelet/pods/9b3755f5-9e50-4f30-b4db-3ff256fd3ffd
/var/snap/microk8s/common/var/lib/kubelet/pods/9b3755f5-9e50-4f30-b4db-3ff256fd3ffd
├── plugins
│   └── kubernetes.io~empty-dir
│       └── wrapped_default-token-lvvg2
│           └── ready
└── volumes
    ├── kubernetes.io~csi
    └── kubernetes.io~secret
        └── default-token-lvvg2
            ├── ca.crt -> ..data/ca.crt
            ├── namespace -> ..data/namespace
            └── token -> ..data/token

7 directories, 4 files
```

does exist, but doesn't include target/mount.