### PR TITLE
Make a unique snapshot for read-write Volumes.

### DIFF
--- a/cmd/plugin/node_server.go
+++ b/cmd/plugin/node_server.go
@@ -75,6 +75,7 @@ func (n nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishV
 	image := req.VolumeId
 	opts := backend.MountOptions{
 		ReadOnly: req.Readonly,
+		VolumeId: req.VolumeId,
 	}
 	secret := ""
 	namespace := ""

--- a/pkg/backend/containerd/mounter.go
+++ b/pkg/backend/containerd/mounter.go
@@ -144,7 +144,12 @@ func (m *mounter) refSnapshot(
 	klog.Infof("prepare %s", parent)
 
 	snapshotter := c.SnapshotService(m.snapshotterName)
-	key := genSnapshotKey(parent)
+	keySuffix := opts.VolumeId
+	if opts.ReadOnly {
+		// ReadOnly volumes can share a single snapshot.
+		keySuffix = parent
+	}
+	key := genSnapshotKey(keySuffix)
 
 	m.snapshotLock.Lock()
 	defer m.snapshotLock.Unlock()

--- a/pkg/backend/mounter.go
+++ b/pkg/backend/mounter.go
@@ -8,6 +8,7 @@ import (
 type MountOptions struct {
 	PullAlways bool
 	ReadOnly   bool
+	VolumeId   string
 }
 
 type Mounter interface {

--- a/pkg/remoteimage/pull.go
+++ b/pkg/remoteimage/pull.go
@@ -108,6 +108,8 @@ func (p puller) Pull(ctx context.Context) (err error) {
 		if err == nil {
 			return
 		}
+
+		pullErrs = append(pullErrs, err)
 	}
 
 	return utilerrors.NewAggregate(pullErrs)


### PR DESCRIPTION
Quoting from the readme:

> All requests to mount the same image also share the same snapshot.

Ideally Volumes that can be mounted RW should not share the same snapshot, otherwise the behavior is unpredictable.

Perhaps the Volume should have an RW option, when set the volume gets a distinct snapshot, when not set volumeMounts must be RO.