### PR TITLE
Pre-provisioned pv can only be mounted as RO

### DIFF
--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -35,7 +35,7 @@ func main() {
 	flag.Parse()
 	driver := csicommon.NewCSIDriver(driverName, driverVersion, *nodeID)
 	driver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
-		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
 	})
 	driver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_UNKNOWN,


### PR DESCRIPTION
As mentioned in https://github.com/warm-metal/csi-driver-image/pull/11, the only safe case is to mount PV as RO.