### PR TITLE
feat(k3s): add the driver manifest for k3s

### DIFF
--- a/install/cri-containerd-k3s.yaml
+++ b/install/cri-containerd-k3s.yaml
@@ -1,0 +1,138 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-image.warm-metal.tech
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-image-warm-metal
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-image-warm-metal
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - pods
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-image-warm-metal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-image-warm-metal
+subjects:
+  - kind: ServiceAccount
+    name: csi-image-warm-metal
+    namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-image-warm-metal
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-image-warm-metal
+  template:
+    metadata:
+      labels:
+        app: csi-image-warm-metal
+    spec:
+      hostNetwork: true
+      serviceAccountName: csi-image-warm-metal
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock"]
+          args:
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-image.warm-metal.tech/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+        - name: plugin
+          image: docker.io/warmmetal/csi-image:v0.4.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--node=$(KUBE_NODE_NAME)"
+            - "--containerd-addr=$(CRI_ADDR)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: HOST_ROOTFS
+              value: /host
+            - name: CRI_ADDR
+              value: unix:///run/containerd/containerd.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /run/containerd/containerd.sock
+              name: runtime-socket
+            - mountPath: /host
+              mountPropagation: Bidirectional
+              name: host-rootfs
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-image.warm-metal.tech
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /
+            type: Directory
+          name: host-rootfs
+        - hostPath:
+            path: /run/k3s/containerd/containerd.sock
+            type: Socket
+          name: runtime-socket


### PR DESCRIPTION
add an install manifest to launch the driver inside a [k3s](https://rancher.com/docs/k3s/latest/en/) cluster.
I have not managed to make it work on k3d which is a wrapping of k3s to run on top of docker but it works fine in k3s.
