### PR TITLE
Removes bind-host

### DIFF
--- a/.github/workflows/backward-compatibility.yaml
+++ b/.github/workflows/backward-compatibility.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - name: Set up minikube
         uses: opsgang/ga-setup-minikube@v0.1.2
         with:
@@ -19,5 +17,7 @@ jobs:
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with containerd
         run: ./hack/ci/setup_containerd_cluster.sh 'v1.21.0'
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Test compatibility with versions prior to v0.4.2
         run: ./test/integration/backward-compatability.sh

--- a/.github/workflows/containerd.yaml
+++ b/.github/workflows/containerd.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - name: Set up minikube
         uses: opsgang/ga-setup-minikube@v0.1.2
         with:
@@ -19,6 +17,8 @@ jobs:
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with containerd
         run: ./hack/ci/setup_containerd_cluster.sh 'v1.21.0'
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Install the CSI Driver
         run: ./hack/ci/install_driver_containerd.sh
       - name: Run integration Tests

--- a/.github/workflows/cri-o.yaml
+++ b/.github/workflows/cri-o.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - name: Set up minikube
         uses: opsgang/ga-setup-minikube@v0.1.2
         with:
@@ -19,6 +17,8 @@ jobs:
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with cri-o
         run: ./hack/ci/setup_crio_cluster.sh 'v1.21.0'
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Install the CSI Driver
         run: ./hack/ci/install_driver_crio.sh
       - name: Run integration Tests

--- a/.github/workflows/docker-containerd.yaml
+++ b/.github/workflows/docker-containerd.yaml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - uses: opsgang/ga-setup-minikube@v0.1.2
         with:
           minikube-version: '1.20.0'
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with docker
         run: ./hack/ci/setup_docker_cluster.sh
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Install the CSI Driver
         run: ./hack/ci/install_driver_containerd.sh
       - name: Run integration Tests

--- a/.github/workflows/restart-ds-containerd.yaml
+++ b/.github/workflows/restart-ds-containerd.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - name: Set up minikube
         uses: opsgang/ga-setup-minikube@v0.1.2
         with:
@@ -19,6 +17,8 @@ jobs:
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with containerd
         run: ./hack/ci/setup_containerd_cluster.sh 'v1.21.0'
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Install the CSI Driver
         run: ./hack/ci/install_driver_containerd.sh
       - name: Test volumes between the ds restarted

--- a/.github/workflows/restart-ds-crio.yaml
+++ b/.github/workflows/restart-ds-crio.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: ./hack/ci/build.sh
       - name: Set up minikube
         uses: opsgang/ga-setup-minikube@v0.1.2
         with:
@@ -19,6 +17,8 @@ jobs:
           k8s-version: '1.21.0'
       - name: Start a Kubernetes cluster with cri-o
         run: ./hack/ci/setup_crio_cluster.sh 'v1.21.0'
+      - name: Build image
+        run: ./hack/ci/build.sh
       - name: Install the CSI Driver
         run: ./hack/ci/install_driver_crio.sh
       - name: Test volumes between the ds restarted

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.16 as builder
+FROM docker.io/library/golang:1.16-alpine3.13 as builder
 
 WORKDIR /go/src/csi-driver-image
 COPY go.mod go.sum ./
@@ -10,7 +10,7 @@ COPY pkg ./pkg
 
 RUN CGO_ENABLED=0 go build -o csi-image-plugin ./cmd/plugin
 
-FROM docker.io/warmmetal/bind-host:v0.2.0
+FROM alpine:3.13
 WORKDIR /
 COPY --from=builder /go/src/csi-driver-image/csi-image-plugin /usr/bin/
-ENTRYPOINT ["bind-host", "-v=1", "--", "csi-image-plugin"]
+ENTRYPOINT ["csi-image-plugin"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+VERSION = v0.5.1
+
+IMAGE_BUILDER ?= docker
+IMAGE_BUILD_CMD ?= buildx
+
+export IMG = docker.io/warmmetal/csi-image:$(VERSION)
+
 .PHONY: build
 build:
 	go vet ./...
@@ -5,7 +12,7 @@ build:
 
 .PHONY: sanity
 sanity:
-	kubectl dev build -t local.test/csi-driver-image-test:sanity test/sanity
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t local.test/csi-driver-image-test:sanity test/sanity
 	kubectl delete --ignore-not-found -f test/sanity/manifest.yaml
 	kubectl apply --wait -f test/sanity/manifest.yaml
 	kubectl -n cliapp-system wait --for=condition=complete job/csi-driver-image-sanity-test
@@ -13,30 +20,33 @@ sanity:
 .PHONY: e2e
 e2e:
 	cp $(shell minikube ssh-key)* test/e2e/
-	kubectl dev build -t local.test/csi-driver-image-test:e2e test/e2e
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t local.test/csi-driver-image-test:e2e test/e2e
 	kubectl delete --ignore-not-found -f test/e2e/manifest.yaml
 	kubectl apply --wait -f test/e2e/manifest.yaml
 	kubectl -n cliapp-system wait --timeout=30m --for=condition=complete job/csi-driver-image-e2e-test
 
 .PHONY: integration
 integration:
-	./test/integration/test-in-minikube-docker.sh
-	./test/integration/test-in-minikube-containerd.sh
-	./test/integration/test-in-minikube-cri-o.sh
 	./test/integration/test-backward-compatability.sh
 	./test/integration/test-restart-ds-containerd.sh
 	./test/integration/test-restart-ds-crio.sh
+	./test/integration/test-restart-runtime-containerd.sh
+	./test/integration/test-restart-runtime-crio.sh
 
 .PHONY: image
 image:
-	kubectl dev build -t docker.io/warmmetal/csi-image:v0.5.1 --push
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t docker.io/warmmetal/csi-image:$(VERSION) --push
 
 .PHONY: local
 local:
-	kubectl dev build -t docker.io/warmmetal/csi-image:v0.5.1
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t docker.io/warmmetal/csi-image:$(VERSION)
 
 .PHONY: test-deps
 test-deps:
-	kubectl dev build --push -t docker.io/warmmetal/csi-image-test:stat-fs -f csi-image-test:stat-fs.dockerfile hack/integration-test-image
-	kubectl dev build --push -t docker.io/warmmetal/csi-image-test:check-fs -f csi-image-test:check-fs.dockerfile hack/integration-test-image
-	kubectl dev build --push -t docker.io/warmmetal/csi-image-test:write-check -f csi-image-test:write-check.dockerfile hack/integration-test-image
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build --push -t docker.io/warmmetal/csi-image-test:stat-fs -f csi-image-test:stat-fs.dockerfile hack/integration-test-image
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build --push -t docker.io/warmmetal/csi-image-test:check-fs -f csi-image-test:check-fs.dockerfile hack/integration-test-image
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build --push -t docker.io/warmmetal/csi-image-test:write-check -f csi-image-test:write-check.dockerfile hack/integration-test-image
+
+.PHONY: install-util
+install-util:
+	GOOS=linux CGO_ENABLED="0" go build -ldflags "-X main.Version=$(VERSION)" -o _output/warm-metal-csi-image-install ./cmd/install

--- a/cmd/install/cri.go
+++ b/cmd/install/cri.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/BurntSushi/toml"
+	"google.golang.org/grpc"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	criapis "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+var typeDir = corev1.HostPathDirectory
+
+func detectImageSvcVolumes(imageSvcSocketPath string) []corev1.Volume {
+	socketUrl := url.URL{
+		Scheme: "unix",
+		Path: imageSvcSocketPath,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, socketUrl.String(), grpc.WithInsecure())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to connect to the CRI image service via %s: %s\n", socketUrl, err)
+		return nil
+	}
+
+	imgSvc := criapis.NewImageServiceClient(conn)
+	resp, err := imgSvc.ImageFsInfo(context.TODO(), &criapis.ImageFsInfoRequest{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to fetch image fsinfo via %s: %s\n", socketUrl.String(), err)
+		return nil
+	}
+
+	var vols []corev1.Volume
+	for i, fs := range resp.ImageFilesystems {
+		if fs.FsId == nil {
+			continue
+		}
+
+		vols = append(vols, corev1.Volume{
+			Name:         fmt.Sprintf("snapshot-root-%d", i),
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fs.FsId.Mountpoint,
+					Type: &typeDir,
+				},
+			},
+		})
+	}
+
+	return vols
+}
+
+type crioRootConfig struct {
+	Crio struct {
+		// Root is a path to the "root directory" where data not
+		// explicitly handled by other options will be stored.
+		Root string `toml:"root"`
+
+		// RunRoot is a path to the "run directory" where state information not
+		// explicitly handled by other options will be stored.
+		RunRoot string `toml:"runroot"`
+	} `toml:"crio"`
+}
+
+func fetchCriOVolumes(socketPath string) []corev1.Volume {
+	cli := &http.Client{Transport: &http.Transport{
+		DisableCompression: true,
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.DialTimeout("unix", socketPath, 32*time.Second)
+		},
+	}}
+
+	req, err := http.NewRequest("GET", "/config", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to fetch crio configuration: %s", err)
+		return nil
+	}
+
+	req.Host = "crio"
+	req.URL.Host = socketPath
+	req.URL.Scheme = "http"
+
+	resp, err := cli.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "unable to fetch crio configuration: %s", err)
+		return nil
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to fetch crio configuration: %s", err)
+		return nil
+	}
+
+	c := &crioRootConfig{}
+	if _, err = toml.Decode(string(body), c); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to fetch crio configuration: %s", err)
+		return nil
+	}
+
+	var vols []corev1.Volume
+	if c.Crio.Root != "" {
+		vols = append(vols, corev1.Volume{
+			Name:         "crio-root",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: c.Crio.Root,
+					Type: &typeDir,
+				},
+			},
+		})
+	}
+
+	if c.Crio.RunRoot != "" {
+		vols = append(vols, corev1.Volume{
+			Name:         "crio-run-root",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: c.Crio.RunRoot,
+					Type: &typeDir,
+				},
+			},
+		})
+	}
+
+	return vols
+}

--- a/cmd/install/kubelet.go
+++ b/cmd/install/kubelet.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mitchellh/go-ps"
+	"github.com/spf13/pflag"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func detectKubeletProcess() *driverConfig {
+	procs, err := ps.Processes()
+	if err != nil {
+		panic(err)
+	}
+
+	k3s := false
+	pid := 0
+	for _, proc := range procs {
+		if proc.Executable() == "kubelet" {
+			pid = proc.Pid()
+			break
+		}
+
+		if proc.Executable() == "k3s-server" {
+			k3s = true
+			break
+		}
+	}
+
+	if k3s {
+		return &driverConfig{
+			KubeletRoot:         "/var/lib/kubelet",
+			Runtime:             Containerd,
+			RuntimeSocketPath:   "/run/k3s/containerd/containerd.sock",
+			ImageSocketPath:     "/run/k3s/containerd/containerd.sock",
+		}
+	}
+
+	if pid == 0 {
+		fmt.Fprintln(os.Stderr, "kubelet process not found")
+	}
+
+	kubeletCmdLine, err := ioutil.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		panic(err)
+	}
+
+	var kubeletArgs []string
+	for _, byt := range bytes.Split(kubeletCmdLine, []byte{0x00}) {
+		kubeletArgs = append(kubeletArgs, string(byt))
+	}
+
+	flags := pflag.NewFlagSet("kubelet", pflag.PanicOnError)
+	flags.ParseErrorsWhitelist.UnknownFlags = true
+
+	rootDirectory := "/var/lib/kubelet"
+	containerRuntime := "docker"
+	remoteRuntimeEndpoint := ""
+	remoteImageEndpoint := ""
+	flags.StringVar(&rootDirectory, "root-dir", rootDirectory, "")
+	flags.StringVar(&containerRuntime, "container-runtime", containerRuntime, "")
+	flags.StringVar(&remoteRuntimeEndpoint, "container-runtime-endpoint", remoteRuntimeEndpoint, "")
+	flags.StringVar(&remoteImageEndpoint, "image-service-endpoint", remoteImageEndpoint, "")
+	flags.Parse(kubeletArgs)
+
+	if containerRuntime == "docker" {
+		fmt.Fprintln(os.Stderr, "Found container runtime docker. Assuming containerd enabled.")
+		remoteRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+	}
+
+	if remoteRuntimeEndpoint == "" && remoteImageEndpoint == "" {
+		fmt.Fprintln(os.Stderr, "container runtime not found")
+		return nil
+	}
+
+	if remoteImageEndpoint == "" {
+		remoteImageEndpoint = remoteRuntimeEndpoint
+	}
+
+	imageSocketPath, err := url.Parse(remoteImageEndpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid image service socket %s\n", remoteImageEndpoint)
+		return nil
+	}
+
+	runtimeSocketPath, err := url.Parse(remoteRuntimeEndpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid runtime socket %s\n", remoteRuntimeEndpoint)
+		return nil
+	}
+
+	var runtime ContainerRuntime
+	if strings.HasSuffix(remoteRuntimeEndpoint, "containerd.sock") {
+		runtime = Containerd
+	} else if strings.HasSuffix(remoteRuntimeEndpoint, "crio.sock") {
+		runtime = CriO
+	} else {
+		fmt.Fprintf(os.Stderr, "unknown container runtime %s\n", remoteRuntimeEndpoint)
+		return nil
+	}
+
+	return &driverConfig{
+		KubeletRoot:       rootDirectory,
+		Runtime:           runtime,
+		RuntimeSocketPath: runtimeSocketPath.Path,
+		ImageSocketPath:   imageSocketPath.Path,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/containerd/containerd v1.5.0-beta.4
 	github.com/containers/storage v1.30.2
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/spf13/pflag v1.0.5
 	github.com/warm-metal/csi-drivers v0.5.0-alpha.0.0.20210404173852-9ec9cb097dd2
@@ -19,6 +20,7 @@ require (
 	k8s.io/klog/v2 v2.8.0
 	k8s.io/kubernetes v1.21.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,8 @@ github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
-docker build -t docker.io/warmmetal/csi-image:$(git rev-parse --short HEAD) .
+IMG=docker.io/warmmetal/csi-image:$(git rev-parse --short HEAD)
+docker build -t ${IMG} .
+minikube image -p csi-image-test load ${IMG}
+make install-util
 set +e

--- a/hack/ci/install_driver_containerd.sh
+++ b/hack/ci/install_driver_containerd.sh
@@ -6,8 +6,7 @@ set -x
 set -e
 
 IMG=docker.io/warmmetal/csi-image:$(git rev-parse --short HEAD)
-minikube image -p csi-image-test load ${IMG}
-lib::install_driver_for_containerd ${IMG}
+lib::install_driver ${IMG}
 
 set +e
 set +x

--- a/hack/ci/install_driver_crio.sh
+++ b/hack/ci/install_driver_crio.sh
@@ -6,8 +6,7 @@ set -x
 set -e
 
 IMG=docker.io/warmmetal/csi-image:$(git rev-parse --short HEAD)
-minikube image -p csi-image-test load ${IMG}
-lib::install_driver_for_crio ${IMG}
+lib::install_driver ${IMG}
 
 set +e
 set +x

--- a/hack/ci/uninstall_driver_containerd.sh
+++ b/hack/ci/uninstall_driver_containerd.sh
@@ -5,7 +5,7 @@ source $(dirname "$0")/../lib/cluster.sh
 set -x
 set -e
 
-lib::uninstall_driver_for_containerd
+lib::uninstall_driver
 
 set +e
 set +x

--- a/hack/ci/uninstall_driver_crio.sh
+++ b/hack/ci/uninstall_driver_crio.sh
@@ -5,7 +5,7 @@ source $(dirname "$0")/../lib/cluster.sh
 set -x
 set -e
 
-lib::install_driver_for_crio
+lib::uninstall_driver
 
 set +e
 set +x

--- a/hack/helper/prepare_containerd_cluster.sh
+++ b/hack/helper/prepare_containerd_cluster.sh
@@ -7,7 +7,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../lib/cluster.sh
 
 echo "Testing on containerd"
 lib::start_cluster_containerd ${K8S_VERSION}
-lib::install_driver_for_containerd
+lib::install_driver
 
 echo "Install a private registry"
 lib::install_private_registry

--- a/install/containerd-k3s.yaml
+++ b/install/containerd-k3s.yaml
@@ -29,16 +29,6 @@ rules:
       - serviceaccounts
     verbs:
       - get
-# If you would like to attach PullImageSecrets to the SA csi-image-warm-metal,
-# enable the following rules and specify secret names.
-#  - apiGroups:
-#      - ""
-#    resourceNames:
-#      - "" # The secret name
-#    resources:
-#      - secrets
-#    verbs:
-#      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -54,9 +44,10 @@ subjects:
     name: csi-image-warm-metal
     namespace: kube-system
 ---
-kind: DaemonSet
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
+  creationTimestamp: null
   name: csi-image-warm-metal
   namespace: kube-system
 spec:
@@ -65,20 +56,12 @@ spec:
       app: csi-image-warm-metal
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: csi-image-warm-metal
     spec:
-      hostNetwork: true
-      serviceAccountName: csi-image-warm-metal
       containers:
-        - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
-          imagePullPolicy: IfNotPresent
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock"]
-          args:
+        - args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-image.warm-metal.tech/csi.sock
           env:
@@ -87,34 +70,40 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock
+          name: node-driver-registrar
+          resources: {}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
-        - name: plugin
-          image: docker.io/warmmetal/csi-image:v0.5.1
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--node=$(KUBE_NODE_NAME)"
-            - "--runtime-addr=$(CRI_ADDR)"
+        - args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --node=$(KUBE_NODE_NAME)
+            - --runtime-addr=$(CRI_ADDR)
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            - name: HOST_ROOTFS
-              value: /host
             - name: CRI_ADDR
-              value: containerd:///run/containerd/containerd.sock
+              value: containerd:///run/k3s/containerd/containerd.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+          image: docker.io/warmmetal/csi-image:v0.5.1
+          imagePullPolicy: IfNotPresent
+          name: plugin
+          resources: {}
           securityContext:
             privileged: true
           volumeMounts:
@@ -123,11 +112,13 @@ spec:
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
-            - mountPath: /run/containerd/containerd.sock
+            - mountPath: /run/k3s/containerd/containerd.sock
               name: runtime-socket
-            - mountPath: /host
+            - mountPath: /var/lib/rancher/k3s/agent/containerd/io.containerd.snapshotter.v1.overlayfs
               mountPropagation: Bidirectional
-              name: host-rootfs
+              name: snapshot-root-0
+      hostNetwork: true
+      serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-image.warm-metal.tech
@@ -142,10 +133,16 @@ spec:
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /
-            type: Directory
-          name: host-rootfs
-        - hostPath:
             path: /run/k3s/containerd/containerd.sock
             type: Socket
           name: runtime-socket
+        - hostPath:
+            path: /var/lib/rancher/k3s/agent/containerd/io.containerd.snapshotter.v1.overlayfs
+            type: Directory
+          name: snapshot-root-0
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0

--- a/install/containerd-microk8s.yaml
+++ b/install/containerd-microk8s.yaml
@@ -29,16 +29,6 @@ rules:
       - serviceaccounts
     verbs:
       - get
-# If you would like to attach PullImageSecrets to the SA csi-image-warm-metal,
-# enable the following rules and specify secret names.
-#  - apiGroups:
-#      - ""
-#    resourceNames:
-#      - "" # The secret name
-#    resources:
-#      - secrets
-#    verbs:
-#      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -54,9 +44,10 @@ subjects:
     name: csi-image-warm-metal
     namespace: kube-system
 ---
-kind: DaemonSet
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
+  creationTimestamp: null
   name: csi-image-warm-metal
   namespace: kube-system
 spec:
@@ -65,20 +56,12 @@ spec:
       app: csi-image-warm-metal
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: csi-image-warm-metal
     spec:
-      hostNetwork: true
-      serviceAccountName: csi-image-warm-metal
       containers:
-        - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
-          imagePullPolicy: IfNotPresent
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock"]
-          args:
+        - args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/snap/microk8s/common/var/lib/kubelet/plugins/csi-image.warm-metal.tech/csi.sock
           env:
@@ -87,34 +70,40 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock
+          name: node-driver-registrar
+          resources: {}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
-        - name: plugin
-          image: docker.io/warmmetal/csi-image:v0.5.1
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--node=$(KUBE_NODE_NAME)"
-            - "--runtime-addr=$(CRI_ADDR)"
+        - args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --node=$(KUBE_NODE_NAME)
+            - --runtime-addr=$(CRI_ADDR)
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            - name: HOST_ROOTFS
-              value: /host
             - name: CRI_ADDR
-              value: containerd:///run/containerd/containerd.sock
+              value: containerd:///var/snap/microk8s/common/run/containerd.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+          image: docker.io/warmmetal/csi-image:v0.5.1
+          imagePullPolicy: IfNotPresent
+          name: plugin
+          resources: {}
           securityContext:
             privileged: true
           volumeMounts:
@@ -123,11 +112,13 @@ spec:
             - mountPath: /var/snap/microk8s/common/var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
-            - mountPath: /run/containerd/containerd.sock
+            - mountPath: /var/snap/microk8s/common/run/containerd.sock
               name: runtime-socket
-            - mountPath: /host
+            - mountPath: /var/snap/microk8s/common/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
               mountPropagation: Bidirectional
-              name: host-rootfs
+              name: snapshot-root-0
+      hostNetwork: true
+      serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:
             path: /var/snap/microk8s/common/var/lib/kubelet/plugins/csi-image.warm-metal.tech
@@ -142,10 +133,16 @@ spec:
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /
-            type: Directory
-          name: host-rootfs
-        - hostPath:
             path: /var/snap/microk8s/common/run/containerd.sock
             type: Socket
           name: runtime-socket
+        - hostPath:
+            path: /var/snap/microk8s/common/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
+            type: Directory
+          name: snapshot-root-0
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0

--- a/test/integration/backward-compatability.sh
+++ b/test/integration/backward-compatability.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
-
 source $(dirname "${BASH_SOURCE[0]}")/../../hack/lib/cluster.sh
-lib::install_driver 'https://raw.githubusercontent.com/warm-metal/csi-driver-image/v0.4.2/install/cri-containerd.yaml'
+lib::install_driver_from_manifest_file 'https://raw.githubusercontent.com/warm-metal/csi-driver-image/v0.4.2/install/cri-containerd.yaml'
 
 TestBase=$(dirname "${BASH_SOURCE[0]}")
 kubectl apply -f "${TestBase}/compatible-manifests/ephemeral-volume.yaml"
@@ -12,8 +11,9 @@ kubectlwait default compatible-ephemeral-volume
 kubectl apply -f "${TestBase}/compatible-manifests/pre-provisioned-pv.yaml"
 kubectlwait default compatible-pre-provisioned-pv
 
-echo "Install the new verson of the driver"
-lib::install_driver_for_containerd
+IMG=${IMG:-warmmetal/csi-image:$(git rev-parse --short HEAD)}
+echo "Install the new verson of the driver using image ${IMG}"
+lib::install_driver "${IMG}"
 
 lib::run_test_job "${TestBase}/manifests/ephemeral-volume.yaml"
 lib::run_test_job "${TestBase}/manifests/readonly-ephemeral-volume.yaml"
@@ -22,6 +22,5 @@ lib::run_test_job "${TestBase}/manifests/pre-provisioned-pv.yaml"
 kubectl delete -f "${TestBase}/compatible-manifests/ephemeral-volume.yaml"
 kubectl delete --ignore-not-found -f "${TestBase}/compatible-manifests/pre-provisioned-pv.yaml"
 
-lib::uninstall_driver_for_containerd
-
+lib::uninstall_driver
 set +e

--- a/test/integration/test-in-minikube-containerd.sh
+++ b/test/integration/test-in-minikube-containerd.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname "${BASH_SOURCE[0]}")/../../hack/helper/prepare_containerd_cluster.sh
 source $(dirname "${BASH_SOURCE[0]}")/cases.sh
-lib::uninstall_driver_for_containerd
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 

--- a/test/integration/test-in-minikube-cri-o.sh
+++ b/test/integration/test-in-minikube-cri-o.sh
@@ -6,7 +6,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../../hack/lib/cluster.sh
 
 echo "Testing on containerd"
 lib::start_cluster_crio ${K8S_VERSION}
-lib::install_driver_for_crio
+lib::install_driver
 
 echo "Install a private registry"
 lib::install_private_registry
@@ -16,7 +16,7 @@ minikube ssh -p csi-image-test -- sudo podman push localhost:31000/warmmetal/csi
 
 source $(dirname "${BASH_SOURCE[0]}")/cases.sh
 
-lib::install_driver_for_crio
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e

--- a/test/integration/test-in-minikube-docker.sh
+++ b/test/integration/test-in-minikube-docker.sh
@@ -6,7 +6,7 @@ echo "Testing on docker"
 lib::start_cluster_docker
 
 set -e
-lib::install_driver_for_containerd
+lib::install_driver
 
 echo "Install a private registry"
 lib::install_private_registry
@@ -16,7 +16,7 @@ minikube ssh -p csi-image-test -- sudo ctr -n k8s.io i push localhost:31000/warm
 
 source $(dirname "${BASH_SOURCE[0]}")/cases.sh
 
-lib::uninstall_driver_for_containerd
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e

--- a/test/integration/test-restart-ds-containerd.sh
+++ b/test/integration/test-restart-ds-containerd.sh
@@ -4,11 +4,11 @@ set -e
 source $(dirname "${BASH_SOURCE[0]}")/../../hack/lib/cluster.sh
 lib::start_cluster_containerd ${K8S_VERSION}
 minikube cache reload -p csi-image-test
-lib::install_driver_for_containerd
+lib::install_driver
 
 source $(dirname "${BASH_SOURCE[0]}")/restart-ds.sh
 
-lib::uninstall_driver_for_containerd
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e

--- a/test/integration/test-restart-ds-crio.sh
+++ b/test/integration/test-restart-ds-crio.sh
@@ -4,11 +4,11 @@ set -e
 source $(dirname "${BASH_SOURCE[0]}")/../../hack/lib/cluster.sh
 lib::start_cluster_crio ${K8S_VERSION}
 minikube cache reload -p csi-image-test
-lib::install_driver_for_crio
+lib::install_driver
 
 source $(dirname "${BASH_SOURCE[0]}")/restart-ds.sh
 
-lib::uninstall_driver_for_crio
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e

--- a/test/integration/test-restart-runtime-containerd.sh
+++ b/test/integration/test-restart-runtime-containerd.sh
@@ -5,14 +5,14 @@ source $(dirname "${BASH_SOURCE[0]}")/../../hack/lib/cluster.sh
 lib::start_cluster_containerd ${K8S_VERSION}
 minikube node -p csi-image-test add
 minikube cache reload -p csi-image-test
-lib::install_driver_for_containerd
+lib::install_driver
 
 minikube ssh -p csi-image-test -n csi-image-test-m02 -- sudo mkdir -p /mnt/vda1/var/lib/boot2docker/etc/containerd
 minikube ssh -p csi-image-test -n csi-image-test-m02 -- sudo cp -rp /etc/containerd/* /var/lib/boot2docker/etc/containerd/
 
 source $(dirname "${BASH_SOURCE[0]}")/restart-runtime.sh 1
 
-lib::uninstall_driver_for_containerd
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e

--- a/test/integration/test-restart-runtime-crio.sh
+++ b/test/integration/test-restart-runtime-crio.sh
@@ -6,14 +6,14 @@ lib::start_cluster_crio ${K8S_VERSION}
 
 minikube -p csi-image-test node add
 minikube cache reload -p csi-image-test
-lib::install_driver_for_crio
+lib::install_driver
 
 minikube ssh -p csi-image-test -n csi-image-test-m02 -- sudo mkdir -p /mnt/vda1/var/lib/boot2docker/etc/crio
 minikube ssh -p csi-image-test -n csi-image-test-m02 -- sudo cp -rp /etc/crio/* /var/lib/boot2docker/etc/crio/
 
 source $(dirname "${BASH_SOURCE[0]}")/restart-runtime.sh 0
 
-lib::uninstall_driver_for_crio
+lib::uninstall_driver
 echo "Destroying cluster"
 minikube delete -p csi-image-test
 set +e


### PR DESCRIPTION
bind-host was introduced(#8) to reduce the complexity of driver installation as the driver requires to mount different host paths for various container runtimes. It fetches required host paths via CRI and APIs of different runtimes and mounts them, but it requires mounting the host rootfs into its pod. It also can't detect a changed kubelet root, then I have to keep manifests for k3s and microk8s in the repo.

I write a binary utility that can run on any node to generate the installation manifests for those various cases. It can detect required host paths then generate proper manifests. bind-host will be removed.