### PR TITLE
Update Makefile to fix docker buildx buidl command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ integration:
 
 .PHONY: image
 image:
-	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t $(REGISTRY)/csi-image:$(VERSION) --push
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t $(REGISTRY)/csi-image:$(VERSION) --push .
 
 .PHONY: local
 local:
-	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t $(REGISTRY)/csi-image:$(VERSION)
+	$(IMAGE_BUILDER) $(IMAGE_BUILD_CMD) build -t $(REGISTRY)/csi-image:$(VERSION) .
 
 .PHONY: test-deps
 test-deps:


### PR DESCRIPTION
Otherwise fails with:
ERROR: "docker buildx build" requires exactly 1 argument.