### PR TITLE
Fix deprecate version for 1.22

### DIFF
--- a/charts/warm-metal-csi-driver/templates/csi-driver.yaml
+++ b/charts/warm-metal-csi-driver/templates/csi-driver.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi-image.warm-metal.tech


### PR DESCRIPTION
Kubernetes removed the `storage.k8s.io/v1beta1` API in 1.22. 

Reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122
