### PR TITLE
fix: unable to pull images from private ECR

### DIFF
--- a/pkg/secret/cache.go
+++ b/pkg/secret/cache.go
@@ -127,7 +127,7 @@ func (s keyringStore) GetDockerKeyring(ctx context.Context, secretData map[strin
 		return credentialprovider.UnionDockerKeyring{preferredKeyring, daemonKeyring}, nil
 	}
 
-	return daemonKeyring, err
+	return credentialprovider.UnionDockerKeyring{daemonKeyring, credentialprovider.NewDockerKeyring()}, err
 }
 
 type secretFetcher struct {


### PR DESCRIPTION
- this started happening since v0.6.0 release of warm metal driver

Fixes #64 