### PR TITLE
Updated values.yaml with latest v0.6.2 patch tag

### DIFF
--- a/charts/warm-metal-csi-driver/Chart.yaml
+++ b/charts/warm-metal-csi-driver/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.5.1
+appVersion: v0.6.2

--- a/charts/warm-metal-csi-driver/values.yaml
+++ b/charts/warm-metal-csi-driver/values.yaml
@@ -5,7 +5,7 @@ runtime:
 kubeletRoot: /var/lib/kubelet
 snapshotRoot: /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
 image:
-  tag: v0.5.1
+  tag: v0.6.2
   repository: docker.io/warmmetal/csi-image
 csiNodeDriverRegistrar:
   image:


### PR DESCRIPTION
latest release v0.6.2 values.yaml is pointing to old tag so updated to latest which is v0.6.2.
we want to this this to be updated in v0.6.2 release