### PR TITLE
feat: async image pull and mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 id_rsa*
 .cache
+vendor

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -51,6 +51,8 @@ var (
 	enableCache = flag.Bool("enable-daemon-image-credential-cache", true,
 		"Whether to save contents of imagepullsecrets of the daemon ServiceAccount in memory. "+
 			"If set to false, secrets will be fetched from the API server on every image pull.")
+	asyncImagePullMount = flag.Bool("async-pull-mount", false,
+		"Whether to pull images asynchronously (helps prevent timeout for larger images)")
 	watcherResyncPeriod = flag.Duration("watcher-resync-period", 30*time.Minute, "The resync period of the pvc watcher.")
 	mode                = flag.String("mode", "", "The mode of the driver. Valid values are: node, controller")
 	nodePluginSA        = flag.String("node-plugin-sa", "csi-image-warm-metal", "The name of the ServiceAccount used by the node plugin.")
@@ -122,10 +124,12 @@ func main() {
 			klog.Fatalf(`unable to connect to cri daemon "%s": %s`, *endpoint, err)
 		}
 
+		secretStore := secret.CreateStoreOrDie(*icpConf, *icpBin, *nodePluginSA, *enableCache)
+
 		server.Start(*endpoint,
 			NewIdentityServer(driverVersion),
 			nil,
-			NewNodeServer(driver, mounter, criClient, secret.CreateStoreOrDie(*icpConf, *icpBin, *nodePluginSA, *enableCache)))
+			NewNodeServer(driver, mounter, criClient, secretStore, *asyncImagePullMount))
 	case controllerMode:
 		watcher, err := watcher.New(context.Background(), *watcherResyncPeriod)
 		if err != nil {

--- a/cmd/plugin/node_server_test.go
+++ b/cmd/plugin/node_server_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+	"github.com/warm-metal/csi-driver-image/pkg/backend"
+	"github.com/warm-metal/csi-driver-image/pkg/backend/containerd"
+	"github.com/warm-metal/csi-driver-image/pkg/cri"
+	csicommon "github.com/warm-metal/csi-drivers/pkg/csi-common"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+// Check test/integration/node-server/README.md for how to run this test correctly
+func TestNodePublishVolumeAsync(t *testing.T) {
+	socketAddr := "unix:///run/containerd/containerd.sock"
+	addr, err := url.Parse(socketAddr)
+	assert.NoError(t, err)
+
+	criClient, err := cri.NewRemoteImageService(socketAddr, time.Minute)
+	assert.NoError(t, err)
+	assert.NotNil(t, criClient)
+
+	mounter := containerd.NewMounter(addr.Path)
+	assert.NotNil(t, mounter)
+
+	driver := csicommon.NewCSIDriver(driverName, driverVersion, "fake-node")
+	assert.NotNil(t, driver)
+
+	asyncImagePulls := true
+	ns := NewNodeServer(driver, mounter, criClient, &testSecretStore{}, asyncImagePulls)
+
+	// based on kubelet's csi mounter pluginc ode
+	// check https://github.com/kubernetes/kubernetes/blob/b06a31b87235784bad2858be62115049b6eb6bcd/pkg/volume/csi/csi_mounter.go#L111-L112
+	timeout := 100 * time.Millisecond
+
+	volId := "docker.io/library/redis:latest"
+	target := "test-path"
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   volId,
+		TargetPath: target,
+		VolumeContext: map[string]string{
+			// so that the test would always attempt to pull an image
+			ctxKeyPullAlways: "true",
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+			},
+		},
+	}
+
+	server := csicommon.NewNonBlockingGRPCServer()
+
+	addr, err = url.Parse(*endpoint)
+	assert.NoError(t, err)
+
+	os.Remove("/csi/csi.sock")
+
+	// automatically deleted when the server is stopped
+	f, err := os.Create("/csi/csi.sock")
+	assert.NoError(t, err)
+	assert.NotNil(t, f)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+
+		server.Start(*endpoint,
+			nil,
+			nil,
+			ns)
+		// wait for the GRPC server to start
+		wg.Done()
+		server.Wait()
+	}()
+
+	// give some time for server to start
+	time.Sleep(2 * time.Second)
+	defer func() {
+		klog.Info("server was stopped")
+		server.Stop()
+	}()
+
+	wg.Wait()
+	var conn *grpc.ClientConn
+
+	conn, err = grpc.Dial(
+		addr.Path,
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, targetPath string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", targetPath)
+		}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+
+	nodeClient := csipbv1.NewNodeClient(conn)
+	assert.NotNil(t, nodeClient)
+
+	condFn := func() (done bool, err error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		resp, err := nodeClient.NodePublishVolume(ctx, req)
+		if err != nil && strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+			klog.Errorf("context deadline exceeded; retrying: %v", err)
+			return false, nil
+		}
+		if resp != nil {
+			return true, nil
+		}
+		return false, fmt.Errorf("response from `NodePublishVolume` is nil")
+	}
+
+	err = wait.PollImmediate(
+		timeout,
+		30*time.Second,
+		condFn)
+	assert.NoError(t, err)
+
+	// give some time before stopping the server
+	time.Sleep(5 * time.Second)
+
+	// unmount if the volume is already mounted
+	c, ca := context.WithTimeout(context.Background(), time.Second*10)
+	defer ca()
+
+	err = mounter.Unmount(c, volId, backend.MountTarget(target))
+	assert.NoError(t, err)
+}
+
+// Check test/integration/node-server/README.md for how to run this test correctly
+func TestNodePublishVolumeSync(t *testing.T) {
+	socketAddr := "unix:///run/containerd/containerd.sock"
+	addr, err := url.Parse(socketAddr)
+	assert.NoError(t, err)
+
+	criClient, err := cri.NewRemoteImageService(socketAddr, time.Minute)
+	assert.NoError(t, err)
+	assert.NotNil(t, criClient)
+
+	mounter := containerd.NewMounter(addr.Path)
+	assert.NotNil(t, mounter)
+
+	driver := csicommon.NewCSIDriver(driverName, driverVersion, "fake-node")
+	assert.NotNil(t, driver)
+
+	asyncImagePulls := false
+	ns := NewNodeServer(driver, mounter, criClient, &testSecretStore{}, asyncImagePulls)
+
+	// based on kubelet's csi mounter pluginc ode
+	// check https://github.com/kubernetes/kubernetes/blob/b06a31b87235784bad2858be62115049b6eb6bcd/pkg/volume/csi/csi_mounter.go#L111-L112
+	timeout := 100 * time.Millisecond
+
+	volId := "docker.io/library/redis:latest"
+	target := "test-path"
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   volId,
+		TargetPath: target,
+		VolumeContext: map[string]string{
+			// so that the test would always attempt to pull an image
+			ctxKeyPullAlways: "true",
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+			},
+		},
+	}
+
+	server := csicommon.NewNonBlockingGRPCServer()
+
+	addr, err = url.Parse(*endpoint)
+	assert.NoError(t, err)
+
+	os.Remove("/csi/csi.sock")
+
+	// automatically deleted when the server is stopped
+	f, err := os.Create("/csi/csi.sock")
+	assert.NoError(t, err)
+	assert.NotNil(t, f)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+
+		server.Start(*endpoint,
+			nil,
+			nil,
+			ns)
+		// wait for the GRPC server to start
+		wg.Done()
+		server.Wait()
+	}()
+
+	// give some time for server to start
+	time.Sleep(2 * time.Second)
+	defer func() {
+		klog.Info("server was stopped")
+		server.Stop()
+	}()
+
+	wg.Wait()
+	var conn *grpc.ClientConn
+
+	conn, err = grpc.Dial(
+		addr.Path,
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, targetPath string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", targetPath)
+		}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+
+	nodeClient := csipbv1.NewNodeClient(conn)
+	assert.NotNil(t, nodeClient)
+
+	condFn := func() (done bool, err error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		resp, err := nodeClient.NodePublishVolume(ctx, req)
+		if err != nil && strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+			klog.Errorf("context deadline exceeded; retrying: %v", err)
+			return false, nil
+		}
+		if resp != nil {
+			return true, nil
+		}
+		return false, fmt.Errorf("response from `NodePublishVolume` is nil")
+	}
+
+	err = wait.PollImmediate(
+		timeout,
+		30*time.Second,
+		condFn)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "timed out waiting for the condition")
+
+	// give some time before stopping the server
+	time.Sleep(5 * time.Second)
+
+	// unmount if the volume is already mounted
+	c, ca := context.WithTimeout(context.Background(), time.Second*10)
+	defer ca()
+
+	err = mounter.Unmount(c, volId, backend.MountTarget(target))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+}
+
+type testSecretStore struct {
+}
+
+func (t *testSecretStore) GetDockerKeyring(ctx context.Context, secrets map[string]string) (credentialprovider.DockerKeyring, error) {
+	return credentialprovider.UnionDockerKeyring{credentialprovider.NewDockerKeyring()}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.0
 	github.com/warm-metal/csi-drivers v0.5.0-alpha.0.0.20210404173852-9ec9cb097dd2
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af
 	google.golang.org/grpc v1.50.0
@@ -91,6 +92,7 @@ require (
 	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/backend/mounter.go
+++ b/pkg/backend/mounter.go
@@ -164,8 +164,7 @@ func (s *SnapshotMounter) unrefROSnapshot(ctx context.Context, target MountTarge
 }
 
 func (s *SnapshotMounter) Mount(
-	ctx context.Context, volumeId string, target MountTarget, image docker.Named, ro bool,
-) (err error) {
+	ctx context.Context, volumeId string, target MountTarget, image docker.Named, ro bool) (err error) {
 	var key SnapshotKey
 	imageID := s.runtime.GetImageIDOrDie(ctx, image)
 	if ro {

--- a/pkg/mountexecutor/mountexecutor.go
+++ b/pkg/mountexecutor/mountexecutor.go
@@ -1,0 +1,129 @@
+package mountexecutor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/containerd/containerd/reference/docker"
+	"github.com/warm-metal/csi-driver-image/pkg/backend"
+	"github.com/warm-metal/csi-driver-image/pkg/mountstatus"
+	"github.com/warm-metal/csi-driver-image/pkg/pullstatus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const (
+	mountPollTimeInterval = 100 * time.Millisecond
+	mountPollTimeout      = 2 * time.Minute
+	mountCtxTimeout       = 10 * time.Minute
+)
+
+// MountExecutorOptions are options passed to mount executor
+type MountExecutorOptions struct {
+	AsyncMount bool
+	Mounter    *backend.SnapshotMounter
+}
+
+// MountOptions are options for a single mount request
+type MountOptions struct {
+	// Context here is only valid for synchronous mounts
+	Context          context.Context
+	NamedRef         docker.Named
+	VolumeId         string
+	TargetPath       string
+	VolumeCapability *csi.VolumeCapability
+	ReadOnly         bool
+}
+
+// MountExecutor executes mount
+type MountExecutor struct {
+	asyncMount bool
+	mutex      *sync.Mutex
+	mounter    *backend.SnapshotMounter
+	asyncErrs  map[docker.Named]error
+}
+
+// NewMountExecutor initializes a new mount executor
+func NewMountExecutor(o *MountExecutorOptions) *MountExecutor {
+	return &MountExecutor{
+		asyncMount: o.AsyncMount,
+		mutex:      &sync.Mutex{},
+		mounter:    o.Mounter,
+	}
+}
+
+// StartMounting starts the mounting
+func (m *MountExecutor) StartMounting(o *MountOptions) error {
+
+	if pullstatus.Get(o.NamedRef) != pullstatus.Pulled || mountstatus.Get(o.VolumeId) == mountstatus.StillMounting {
+		klog.Infof("image '%s' hasn't been pulled yet (status: %s) or volume is still mounting (status: %s)",
+			o.NamedRef.Name(),
+			pullstatus.Get(o.NamedRef), mountstatus.Get(o.VolumeId))
+		return nil
+	}
+
+	ro := o.ReadOnly ||
+		o.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY ||
+		o.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+
+	if !m.asyncMount {
+		mountstatus.Update(o.VolumeId, mountstatus.StillMounting)
+		if err := m.mounter.Mount(o.Context, o.VolumeId, backend.MountTarget(o.TargetPath), o.NamedRef, ro); err != nil {
+			mountstatus.Update(o.VolumeId, mountstatus.Errored)
+			return err
+		}
+		mountstatus.Update(o.VolumeId, mountstatus.Mounted)
+		return nil
+	}
+
+	go func() {
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), mountCtxTimeout)
+		defer cancel()
+
+		mountstatus.Update(o.VolumeId, mountstatus.StillMounting)
+		if err := m.mounter.Mount(ctx, o.VolumeId, backend.MountTarget(o.TargetPath), o.NamedRef, ro); err != nil {
+			klog.Errorf("mount err: %v", err.Error())
+			mountstatus.Update(o.VolumeId, mountstatus.Errored)
+			m.asyncErrs[o.NamedRef] = fmt.Errorf("err: %v: %v", err, m.asyncErrs[o.NamedRef])
+			return
+		}
+		mountstatus.Update(o.VolumeId, mountstatus.Mounted)
+	}()
+
+	return nil
+}
+
+// WaitForMount waits for the volume to get mounted
+func (m *MountExecutor) WaitForMount(o *MountOptions) error {
+	if pullstatus.Get(o.NamedRef) != pullstatus.Pulled {
+		return nil
+	}
+
+	if !m.asyncMount {
+		return nil
+	}
+
+	mountCondFn := func() (done bool, err error) {
+		if mountstatus.Get(o.VolumeId) == mountstatus.Mounted {
+			return true, nil
+		}
+		if m.asyncErrs[o.NamedRef] != nil {
+			return false, m.asyncErrs[o.NamedRef]
+		}
+		return false, nil
+	}
+
+	if err := wait.PollImmediate(
+		mountPollTimeInterval,
+		mountPollTimeout,
+		mountCondFn); err != nil {
+		return fmt.Errorf("waited too long to mount the image: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/mountstatus/mountstatus.go
+++ b/pkg/mountstatus/mountstatus.go
@@ -1,0 +1,63 @@
+package mountstatus
+
+import (
+	"sync"
+)
+
+// ImagePullStatus represents mount status of an image
+type ImageMountStatus int
+
+// https://stackoverflow.com/questions/14426366/what-is-an-idiomatic-way-of-representing-enums-in-go
+const (
+	// StatusNotFound means there has been no attempt to mount the image
+	StatusNotFound ImageMountStatus = -1
+	// StillMounting means the image is still being mounted as a volume
+	StillMounting ImageMountStatus = iota
+	// Mounted means the image has been mounted as a volume
+	Mounted
+	// Errored means there was an error during image mount
+	Errored
+)
+
+// ImageMountStatusRecorder records the status of image mounts
+type ImageMountStatusRecorder struct {
+	status map[string]ImageMountStatus
+	mutex  sync.Mutex
+}
+
+var i ImageMountStatusRecorder
+
+func init() {
+	i = ImageMountStatusRecorder{
+		status: make(map[string]ImageMountStatus),
+		mutex:  sync.Mutex{},
+	}
+}
+
+// Update updates the mount status of an image
+func Update(volumeId string, status ImageMountStatus) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	i.status[volumeId] = status
+}
+
+// Delete deletes the mount status of an image
+func Delete(volumeId string) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	delete(i.status, volumeId)
+}
+
+// Get gets the mount status of an image
+func Get(volumeId string) ImageMountStatus {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	if _, ok := i.status[volumeId]; !ok {
+		return StatusNotFound
+	}
+
+	return i.status[volumeId]
+}

--- a/pkg/pullexecutor/pullexecutor.go
+++ b/pkg/pullexecutor/pullexecutor.go
@@ -1,0 +1,148 @@
+package pullexecutor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/reference/docker"
+	"github.com/pkg/errors"
+	"github.com/warm-metal/csi-driver-image/pkg/backend"
+	"github.com/warm-metal/csi-driver-image/pkg/pullstatus"
+	"github.com/warm-metal/csi-driver-image/pkg/remoteimage"
+	"github.com/warm-metal/csi-driver-image/pkg/secret"
+	"k8s.io/apimachinery/pkg/util/wait"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/klog/v2"
+)
+
+const (
+	pullPollTimeInterval = 100 * time.Millisecond
+	pullPollTimeout      = 2 * time.Minute
+	pullCtxTimeout       = 10 * time.Minute
+)
+
+// PullExecutorOptions are the options passed to the pull executor
+type PullExecutorOptions struct {
+	AsyncPull          bool
+	ImageServiceClient cri.ImageServiceClient
+	SecretStore        secret.Store
+	Mounter            *backend.SnapshotMounter
+}
+
+// PullOptions are the options for a single pull request
+type PullOptions struct {
+	// Context here is only valid for synchronous mounts
+	Context     context.Context
+	NamedRef    docker.Named
+	PullAlways  bool
+	PullSecrets map[string]string
+	Image       string
+}
+
+// PullExecutor executes the pulls
+type PullExecutor struct {
+	asyncPull      bool
+	imageSvcClient cri.ImageServiceClient
+	mutex          *sync.Mutex
+	asyncErrs      map[docker.Named]error
+	secretStore    secret.Store
+	mounter        *backend.SnapshotMounter
+}
+
+// NewPullExecutor initializes a new pull executor object
+func NewPullExecutor(o *PullExecutorOptions) *PullExecutor {
+	return &PullExecutor{
+		asyncPull:      o.AsyncPull,
+		mutex:          &sync.Mutex{},
+		imageSvcClient: o.ImageServiceClient,
+		secretStore:    o.SecretStore,
+		mounter:        o.Mounter,
+	}
+}
+
+// StartPulling starts pulling the image
+func (m *PullExecutor) StartPulling(o *PullOptions) error {
+
+	keyring, err := m.secretStore.GetDockerKeyring(o.Context, o.PullSecrets)
+	if err != nil {
+		return errors.Errorf("unable to fetch keyring: %s", err)
+	}
+
+	if !m.asyncPull {
+		puller := remoteimage.NewPuller(m.imageSvcClient, o.NamedRef, keyring)
+		shouldPull := o.PullAlways || !m.mounter.ImageExists(o.Context, o.NamedRef)
+		if shouldPull {
+			klog.Infof("pull image %q ", o.Image)
+			pullstatus.Update(o.NamedRef, pullstatus.StillPulling)
+			if err = puller.Pull(o.Context); err != nil {
+				pullstatus.Update(o.NamedRef, pullstatus.Errored)
+				return errors.Errorf("unable to pull image %q: %s", o.NamedRef, err)
+			}
+		}
+		pullstatus.Update(o.NamedRef, pullstatus.Pulled)
+		return nil
+	}
+
+	if pullstatus.Get(o.NamedRef) == pullstatus.Pulled ||
+		pullstatus.Get(o.NamedRef) == pullstatus.StillPulling {
+		return nil
+	}
+
+	go func() {
+		if pullstatus.Get(o.NamedRef) == pullstatus.StatusNotFound {
+			m.mutex.Lock()
+			defer m.mutex.Unlock()
+			c, cancel := context.WithTimeout(context.Background(), pullCtxTimeout)
+			defer cancel()
+
+			if pullstatus.Get(o.NamedRef) == pullstatus.StillPulling {
+				return
+			}
+
+			puller := remoteimage.NewPuller(m.imageSvcClient, o.NamedRef, keyring)
+			shouldPull := o.PullAlways || !m.mounter.ImageExists(o.Context, o.NamedRef)
+			if shouldPull {
+				klog.Infof("pull image %q ", o.Image)
+				pullstatus.Update(o.NamedRef, pullstatus.StillPulling)
+				if err = puller.Pull(c); err != nil {
+					pullstatus.Update(o.NamedRef, pullstatus.Errored)
+					m.asyncErrs[o.NamedRef] = fmt.Errorf("unable to pull image %q: %s", o.Image, err)
+					return
+				}
+				pullstatus.Update(o.NamedRef, pullstatus.Pulled)
+
+			}
+		}
+	}()
+
+	return nil
+}
+
+// WaitForPull waits until the image pull succeeds or errors or timeout is exceeded
+func (m *PullExecutor) WaitForPull(o *PullOptions) error {
+	if !m.asyncPull {
+		return nil
+	}
+
+	condFn := func() (done bool, err error) {
+		if pullstatus.Get(o.NamedRef) == pullstatus.Pulled {
+			return true, nil
+		}
+
+		if m.asyncErrs[o.NamedRef] != nil {
+			return false, m.asyncErrs[o.NamedRef]
+		}
+		return false, nil
+	}
+
+	if err := wait.PollImmediate(
+		pullPollTimeInterval,
+		pullPollTimeout,
+		condFn); err != nil {
+		return errors.Errorf("waited too long to download the image: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/pullstatus/pullstatus.go
+++ b/pkg/pullstatus/pullstatus.go
@@ -1,0 +1,65 @@
+package pullstatus
+
+import (
+	"sync"
+
+	"github.com/containerd/containerd/reference/docker"
+)
+
+// ImagePullStatus represents pull status of an image
+type ImagePullStatus int
+
+// https://stackoverflow.com/questions/14426366/what-is-an-idiomatic-way-of-representing-enums-in-go
+const (
+	// StatusNotFound means there has been no attempt to pull the image
+	StatusNotFound ImagePullStatus = -1
+	// StillPulling means the image is still being pulled
+	StillPulling ImagePullStatus = iota
+	// Pulled means the image has been pulled
+	Pulled
+	// Errored means there was an error during image pull
+	Errored
+)
+
+// ImagePullStatusRecorder records the status of image pulls
+type ImagePullStatusRecorder struct {
+	status map[docker.Named]ImagePullStatus
+	mutex  sync.Mutex
+}
+
+var i ImagePullStatusRecorder
+
+func init() {
+	i = ImagePullStatusRecorder{
+		status: make(map[docker.Named]ImagePullStatus),
+		mutex:  sync.Mutex{},
+	}
+}
+
+// Update updates the pull status of an image
+func Update(imageRef docker.Named, status ImagePullStatus) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	i.status[imageRef] = status
+}
+
+// Delete deletes the pull status of an image
+func Delete(imageRef docker.Named) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	delete(i.status, imageRef)
+}
+
+// Get gets the pull status of an image
+func Get(imageRef docker.Named) ImagePullStatus {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	if _, ok := i.status[imageRef]; !ok {
+		return StatusNotFound
+	}
+
+	return i.status[imageRef]
+}

--- a/pkg/remoteimage/pull.go
+++ b/pkg/remoteimage/pull.go
@@ -13,7 +13,8 @@ type Puller interface {
 	Pull(context.Context) error
 }
 
-func NewPuller(imageSvc cri.ImageServiceClient, image docker.Named, keyring credentialprovider.DockerKeyring) Puller {
+func NewPuller(imageSvc cri.ImageServiceClient, image docker.Named,
+	keyring credentialprovider.DockerKeyring) Puller {
 	return &puller{
 		imageSvc: imageSvc,
 		image:    image,

--- a/pkg/remoteimage/pull_test.go
+++ b/pkg/remoteimage/pull_test.go
@@ -1,0 +1,30 @@
+package remoteimage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/warm-metal/csi-driver-image/pkg/cri"
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// Check test/integration/node-server/README.md for how to run this test correctly
+func TestPull(t *testing.T) {
+	testImage := "docker.io/library/redis:latest"
+	socketAddr := "unix:///run/containerd/containerd.sock"
+	// addr, err := url.Parse(socketAddr)
+	// assert.NoError(t, err)
+	criClient, err := cri.NewRemoteImageService(socketAddr, time.Minute)
+	assert.NoError(t, err)
+	assert.NotNil(t, criClient)
+
+	r, err := criClient.PullImage(context.Background(), &v1alpha2.PullImageRequest{
+		Image: &v1alpha2.ImageSpec{
+			Image: testImage,
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+}

--- a/test/integration/node-server/Dockerfile.containerd
+++ b/test/integration/node-server/Dockerfile.containerd
@@ -1,0 +1,28 @@
+# bookworm is name of the latest debian release at the time of writing this
+FROM golang:1.19-bookworm
+
+# Based on https://docs.docker.com/engine/install/debian/
+
+# Add Docker's official GPG key:
+RUN  apt-get update
+RUN  apt-get install ca-certificates curl gnupg
+RUN  install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg |  gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN  chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" |  tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN  apt-get update
+
+RUN apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+RUN apt-get install libbtrfs-dev libgpgme-dev libdevmapper-dev -y
+
+# Install CNI plugins
+RUN curl -LO https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-amd64-v1.3.0.tgz
+RUN mkdir -p /opt/cni/bin
+RUN tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.3.0.tgz
+# To enable CRI plugin in containerd
+RUN sed -i 's/disabled_plugins/#disabled_plugins/g' /etc/containerd/config.toml
+# Directory for node server's csi socket
+RUN mkdir /csi
+# Fixes https://github.com/containers/buildah/issues/2922

--- a/test/integration/node-server/README.md
+++ b/test/integration/node-server/README.md
@@ -1,0 +1,83 @@
+## What is this? 
+This directory contains two files:
+1. `docker-compose.yaml`: used to mount workspace on image built using `Dockerfile.containerd`
+2. `Dockerfile.containerd`: used to run containerd
+
+## Why?
+This is to test `cmd/plugin/node_server_test.go` and `pkg/remoteimage/pull_test.go`
+
+## How to run the tests?
+Build the image
+```shell
+$ docker build . -f Dockerfile.containerd  -t <image-name>:<tag>
+```
+For example
+```shell
+$ docker build . -f Dockerfile.containerd  -t containerd-on-mac:0.6
+```
+
+Start using the image:
+```
+$ docker-compose up
+```
+
+For example:
+```shell
+$ docker-compose up
+[+] Building 0.0s (0/0)                                                                                                              docker:desktop-linux
+[+] Running 1/0
+ ✔ Container node-server-containerd-workspace-1  Recreated                                                                                           0.0s 
+Attaching to node-server-containerd-workspace-1
+node-server-containerd-workspace-1  | time="2023-11-08T09:03:00Z" level=warning msg="containerd config version `1` has been deprecated and will be removed in containerd v2.0, please switch to version `2`, see https://github.com/containerd/containerd/blob/main/docs/PLUGINS.md#version-header"
+node-server-containerd-workspace-1  | time="2023-11-08T09:03:00.484125750Z" level=info msg="starting containerd" revision=61f9fd88f79f081d64d6fa3bb1a0dc71ec870523 version=1.6.24
+node-server-containerd-workspace-1  | time="2023-11-08T09:03:00.491186708Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
+...
+```
+
+`exec` into the docker container:
+```
+$ docker ps
+```
+For example:
+```shell
+$ docker ps
+CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS          PORTS                      NAMES
+7769b9e621f1   containerd-on-mac:0.6   "containerd"             24 minutes ago   Up 24 minutes                              node-server-containerd-workspace-1
+```
+
+Get the `CONTAINER ID` and `exec` into it using:
+```shell
+$ docker exec -it <CONTAINER ID> bash
+```
+For example:
+```shell
+$ docker exec -it 7769b9e621f1 bash                                                                                    ~ 
+root@7769b9e621f1:/go#
+```
+
+**To run `TestNodePublishVolume`**:
+
+`cd` into `/code/cmd/plugin` and run `go test -run 'TestNodePublishVolume'` (note that `TestNodePublishVolume` is a regex)
+```
+root@7769b9e621f1:/go# cd /code/cmd/plugin
+root@7769b9e621f1:/code/cmd/plugin# go test -run 'TestNodePublishVolume'
+I1108 10:27:03.784182   19936 mounter.go:45] load 0 snapshots from runtime
+I1108 10:27:03.787347   19936 server.go:108] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
+...
+I1108 10:27:13.222601   19936 node_server_test.go:94] server was stopped
+I1108 10:27:13.225907   19936 mounter.go:45] load 0 snapshots from runtime
+I1108 10:27:13.235697   19936 server.go:108] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
+...
+PASS
+ok  	github.com/warm-metal/csi-driver-image/cmd/plugin	46.711s
+```
+
+**To test `TestPull`**:
+`cd` into `/code/pkg/remoteimage` and run `go test -run 'TestPull'` (note that `TestPull` is a regex)
+```
+root@cdf7ee254501:~# cd /code/pkg/remoteimage
+root@cdf7ee254501:/code/pkg/remoteimage# go test -run 'TestPull'
+PASS
+ok  	github.com/warm-metal/csi-driver-image/pkg/remoteimage	2.247s
+root@cdf7ee254501:/code/pkg/remoteimage#
+```

--- a/test/integration/node-server/docker-compose.yaml
+++ b/test/integration/node-server/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+    containerd-workspace:
+        # replace the image here with the image you built using `Dockerfile.containerd`
+        image: containerd-on-mac:0.6
+        privileged: true # to enable mount/unmount operations
+        command: containerd
+        # mount code in the current repo to `/code` path in the container
+        volumes:
+          - ../../../.:/code


### PR DESCRIPTION
### Problem
warm metal driver throws `context deadline exceeded` errors 
* when used in cluster with high pod churn/activity
* when the size of the image is too large

This happens because
* warm metal doesn't resume download of image in the second, third, fourth ... attempt if the first attempt failed. It starts from scratch every time
* kubelet has a hard timeout of 2m for GRPC requests. Since warm metal serves the request synchronously, images have to be pulled within 2m. 

### Solution
We pull and mount images asynchronously so that: 
1. Even if the first request from kubelet fails (due to timeout), warm metal continues to pull and mount the image in the background so that next requests from kubelet would succeeed
2. We expose asynchronous image pulling and mounting as a commandline option so that users can enable/disable it

### Tests
<details>
<summary>
 With asynchronous pull and mount:
</summary>

```
root@cdf7ee254501:/code/cmd/plugin# go test -run 'TestNodePublishVolumeAsync'
I1108 10:40:04.407812     853 mounter.go:45] load 0 snapshots from runtime
I1108 10:40:04.410577     853 server.go:108] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I1108 10:40:06.419940     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=18b4d43e-1b30-4790-8233-02d8b627e334)
I1108 10:40:06.426363     853 pullexecutor.go:97] pull image "docker.io/library/redis:latest"
E1108 10:40:06.518674     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:06.622587     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=8bf3146b-424c-4981-96e6-cecdcf69abb8)
E1108 10:40:06.722786     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:06.822109     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=c2447ef6-ec61-4426-94e3-e40df32b8318)
E1108 10:40:06.922087     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:07.024885     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=1ba0ef13-b149-47bf-883c-87fbb6793d4b)
E1108 10:40:07.123843     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:07.224659     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=093b8bdd-412b-4a90-a00b-7bc06ee36e3f)
E1108 10:40:07.324687     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:07.420104     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=bcc63fe0-0031-449a-8e42-3a4e3d9ad2c0)
E1108 10:40:07.522951     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:07.624685     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=18383b25-6e39-4742-b0dd-df290692bfd4)
E1108 10:40:07.724119     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:07.820916     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=fa744426-0932-4a5f-a922-107ebe8a26b9)
E1108 10:40:07.920573     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.022154     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=10e42084-1393-4cc8-bbef-0aede91b2186)
E1108 10:40:08.124091     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.222235     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=16bf770d-ae06-43a8-86b0-21978ef39b12)
E1108 10:40:08.324075     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.422891     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=84a75da1-bfc7-411a-ad56-dcb1347191b3)
E1108 10:40:08.522908     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.620155     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=271cc66b-017e-4d4f-becc-c759a60b2b9b)
E1108 10:40:08.723800     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.820847     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=13e3d579-822a-4f35-9007-c10bb51835ad)
E1108 10:40:08.920222     853 node_server_test.go:123] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:40:08.938543     853 containerd.go:82] image "docker.io/library/redis:latest" unpacked
I1108 10:40:08.941227     853 mounter.go:177] refer read-only snapshot of image "docker.io/library/redis:latest" with key "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28"
I1108 10:40:08.941259     853 mounter.go:116] create snapshot "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" of image "sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" and refer it
I1108 10:40:08.941296     853 containerd.go:99] create ro snapshot "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" for image "sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" with metadata map[string]string{"containerd.io/gc.root":"2023-11-08T10:40:08Z", "csi-image.warm-metal.tech/target|test-path":"√"}
I1108 10:40:08.943600     853 mounter.go:125] snapshot "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" is shared by 1 volumes
I1108 10:40:09.023588     853 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=cfb6f2f5-4973-4074-94a3-c0dd49e2c1e7)
I1108 10:40:14.033213     853 mounter.go:211] unmount volume "docker.io/library/redis:latest" at "test-path"
I1108 10:40:14.034725     853 mounter.go:216] try to unref read-only snapshot
I1108 10:40:14.034757     853 mounter.go:155] snapshot "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28" isn't used by other volumes. delete it
I1108 10:40:14.034796     853 containerd.go:189] remove snapshot "csi-image.warm-metal.tech-sha256:9075a3a4d047ee389b94ebcce57958440bf0b07dc7de1b69df90b75a57665c28"
I1108 10:40:14.041244     853 node_server_test.go:94] server was stopped
PASS
ok  	github.com/warm-metal/csi-driver-image/cmd/plugin	9.661s
```

</details>

<details>
<summary>
With synchronous pull and mount:
</summary>

```
root@cdf7ee254501:/code/cmd/plugin# go test -run 'TestNodePublishVolumeSync'
I1108 10:41:04.481074    1239 mounter.go:45] load 0 snapshots from runtime
I1108 10:41:04.483854    1239 server.go:108] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I1108 10:41:06.487828    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=87042018-3ab9-4910-adc8-a2dcc82d85d8)
I1108 10:41:06.496336    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:06.589885    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:06.589970    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:41:06.692623    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=72d5a350-d9ea-4a37-9736-aa658fa816b2)
I1108 10:41:06.698974    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:06.792714    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:06.792754    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:41:06.892533    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=fce7da24-b806-4cff-a579-d5f0554c068c)
I1108 10:41:06.896913    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:06.992312    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:06.992328    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:41:07.092163    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=1047530e-c016-41e0-b30a-dcec76c93e2b)
I1108 10:41:07.097247    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:07.192077    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:07.192177    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:41:07.295193    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=027ce974-9185-4a84-896f-e554a9e8ca38)
I1108 10:41:07.298117    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:07.395878    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:07.395888    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
I1108 10:41:07.495071    1239 node_server.go:66] mount request: volume_id:"docker.io/library/redis:latest" target_path:"test-path" volume_capability:<access_mode:<mode:SINGLE_NODE_READER_ONLY > > volume_context:<key:"pullAlways" value:"true" >  %!(EXTRA string=reqId , string=b58498e2-6ce8-4ce9-b853-b495595a0b00)
I1108 10:41:07.502611    1239 pullexecutor.go:70] pull image "docker.io/library/redis:latest"
E1108 10:41:07.594498    1239 node_server_test.go:245] context deadline exceeded; retrying: rpc error: code = DeadlineExceeded desc = context deadline exceeded
E1108 10:41:07.594566    1239 utils.go:101] GRPC error: rpc error: code = Aborted desc = unable to pull image "docker.io/library/redis:latest": unable to pull image "docker.io/library/redis:latest": rpc error: code = DeadlineExceeded desc = context deadline exceeded
... continues

I1108 10:41:41.699399    1239 mounter.go:211] unmount volume "docker.io/library/redis:latest" at "test-path"
I1108 10:41:41.700355    1239 mounter.go:216] try to unref read-only snapshot
I1108 10:41:41.700382    1239 mounter.go:135] target "test-path" is not read-only
I1108 10:41:41.700401    1239 mounter.go:222] delete the read-write snapshot
I1108 10:41:41.700482    1239 containerd.go:189] remove snapshot "csi-image.warm-metal.tech-docker.io/library/redis:latest"
E1108 10:41:41.702751    1239 containerd.go:192] unable to remove the snapshot "csi-image.warm-metal.tech-docker.io/library/redis:latest": snapshot csi-image.warm-metal.tech-docker.io/library/redis:latest does not exist: not found
I1108 10:41:41.702819    1239 node_server_test.go:216] server was stopped
PASS
ok  	github.com/warm-metal/csi-driver-image/cmd/plugin	37.253s
```

Note that **test passing here means**, warm metal **was not able to mount the image within 37 seconds**
</details>

