### PR TITLE
fix: v0.6.x remove node driver registrar lifecycle hook

### DIFF
--- a/charts/warm-metal-csi-driver/Chart.yaml
+++ b/charts/warm-metal-csi-driver/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.6.3
+appVersion: v0.6.4

--- a/charts/warm-metal-csi-driver/templates/daemon-set.yaml
+++ b/charts/warm-metal-csi-driver/templates/daemon-set.yaml
@@ -25,13 +25,6 @@ spec:
                   fieldPath: spec.nodeName
           image: {{ .Values.csiNodeDriverRegistrar.image.repository }}:{{ .Values.csiNodeDriverRegistrar.image.tag }}
           imagePullPolicy: IfNotPresent
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - rm -rf /registration/csi-image.warm-metal.tech /registration/csi-image.warm-metal.tech-reg.sock
           name: node-driver-registrar
           resources: {}
           volumeMounts:

--- a/charts/warm-metal-csi-driver/values.yaml
+++ b/charts/warm-metal-csi-driver/values.yaml
@@ -9,5 +9,5 @@ image:
   repository: docker.io/warmmetal/csi-image
 csiNodeDriverRegistrar:
   image:
-    tag: v1.1.0
-    repository: quay.io/k8scsi/csi-node-driver-registrar
+    tag: v2.8.0
+    repository: registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
This is a port of https://github.com/warm-metal/csi-driver-image/pull/70 (same description applies here)