### PR TITLE
feat: Build and push docker images via GitHub Actions

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -2,6 +2,7 @@
 name: Create and publish the container image.
 
 on:
+  push:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -8,10 +8,6 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,49 @@
+#
+name: Create and publish the container image.
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          #tags: |
+          #  type=schedule
+          #  type=ref,event=branch
+          #  type=ref,event=pr
+          #  type=semver,pattern={{version}}
+          #  type=semver,pattern={{major}}.{{minor}}
+          #  type=semver,pattern={{major}}
+          #  type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,13 +1,9 @@
-#
 name: Create and publish the container image.
 
 on:
   push:
-  workflow_dispatch:
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    branches: [master]
+  tags:
 
 jobs:
   build-and-push-image:
@@ -20,29 +16,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          #tags: |
-          #  type=schedule
-          #  type=ref,event=branch
-          #  type=ref,event=pr
-          #  type=semver,pattern={{version}}
-          #  type=semver,pattern={{major}}.{{minor}}
-          #  type=semver,pattern={{major}}
-          #  type=sha
+          images: |
+            warmmetal/csi-image
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # set image tag based on GitHub release tag
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true


### PR DESCRIPTION
Closes #84 

### What the changes do

- On push to `master` which is the default branch for this repository, will push the image with the `latest` tag.
- On creation of a GitHub tag, will push the image with the tag being equal to the GitHub tag.