### PR TITLE
Add csi-maintainers team in GitHub CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @warm-metal/csi-maintainers


### PR DESCRIPTION
Closes #94 

Added CODEOWNERS file for GitHub.