### PR TITLE
feat: make `hostNetwork` configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v1.0.0
+VERSION ?= v1.0.1
 
 IMAGE_BUILDER ?= docker
 IMAGE_BUILD_CMD ?= buildx

--- a/charts/warm-metal-csi-driver/Chart.yaml
+++ b/charts/warm-metal-csi-driver/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.0.0
+appVersion: v1.0.1

--- a/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
+++ b/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
@@ -122,7 +122,7 @@ spec:
             - mountPath: {{ .Values.crioMountProgram }}
               name: crio-mount-program
             {{- end }}
-      hostNetwork: true
+      hostNetwork: {{.Values.hostNetwork}}
       serviceAccountName: {{ include "warm-metal-csi-driver.fullname" . }}-nodeplugin
       volumes:
         - hostPath:

--- a/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
+++ b/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
@@ -122,7 +122,7 @@ spec:
             - mountPath: {{ .Values.crioMountProgram }}
               name: crio-mount-program
             {{- end }}
-      hostNetwork: {{.Values.hostNetwork}}
+      hostNetwork: {{.Values.csiPlugin.hostNetwork}}
       serviceAccountName: {{ include "warm-metal-csi-driver.fullname" . }}-nodeplugin
       volumes:
         - hostPath:

--- a/charts/warm-metal-csi-driver/values.yaml
+++ b/charts/warm-metal-csi-driver/values.yaml
@@ -9,6 +9,7 @@ enableAsyncPullMount: false
 pullImageSecretForDaemonset:
 
 csiPlugin:
+  hostNetwork: false
   resources: {}
   image:
     tag: ""

--- a/cmd/install/main.go
+++ b/cmd/install/main.go
@@ -278,7 +278,7 @@ spec:
       labels:
         app: csi-image-warm-metal
     spec:
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: csi-image-warm-metal
       containers:
         - name: node-driver-registrar

--- a/pkg/pullexecutor/pullexecutor.go
+++ b/pkg/pullexecutor/pullexecutor.go
@@ -102,7 +102,8 @@ func (m *PullExecutor) StartPulling(o *PullOptions) error {
 			c, cancel := context.WithTimeout(context.Background(), pullCtxTimeout)
 			defer cancel()
 
-			if pullstatus.Get(o.NamedRef) == pullstatus.StillPulling {
+			if pullstatus.Get(o.NamedRef) == pullstatus.StillPulling ||
+				pullstatus.Get(o.NamedRef) == pullstatus.Pulled {
 				return
 			}
 

--- a/sample/install/cri-o.yaml
+++ b/sample/install/cri-o.yaml
@@ -126,7 +126,7 @@ spec:
             - mountPath: /run/containers/storage
               mountPropagation: Bidirectional
               name: crio-run-root
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:

--- a/sample/install/k3s-containerd.yaml
+++ b/sample/install/k3s-containerd.yaml
@@ -117,7 +117,7 @@ spec:
             - mountPath: /var/lib/rancher/k3s/agent/containerd/io.containerd.snapshotter.v1.overlayfs
               mountPropagation: Bidirectional
               name: snapshot-root-0
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:

--- a/sample/install/minikube-containerd.yaml
+++ b/sample/install/minikube-containerd.yaml
@@ -123,7 +123,7 @@ spec:
             - mountPath: /mnt/vda1/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
               mountPropagation: Bidirectional
               name: snapshot-root-0
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:

--- a/sample/install/snap-microk8s-containerd.yaml
+++ b/sample/install/snap-microk8s-containerd.yaml
@@ -117,7 +117,7 @@ spec:
             - mountPath: /var/snap/microk8s/common/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
               mountPropagation: Bidirectional
               name: snapshot-root-0
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: csi-image-warm-metal
       volumes:
         - hostPath:


### PR DESCRIPTION
- disable it by default (fixes port conflict issue on the node if another port is trying to acquire the same port)

### Why
We use `hostNetwork: true` by default which causes problems in the following scenario:
1. another-csi-driver pod is running on the same node A
2. another-csi-driver uses port 8080
3. warm-metal pod is scheduled on node A
4. warm-metal pod tries to use port 8080 as well (for metrics endpoint) but fails because the port is already in use

This happens because we use `hostNetwork: true`. Based on my tests and analysis (along with integration tests), we don't really need `hostNetwork` because we are not accessing anything on the node nor is the node accessing anything on the warm-metal pod directly. 

### More info
hostNetwork has been a part of the initial commit: https://github.com/warm-metal/csi-driver-image/commit/515cec1b144bda269a87ec78f46203f5686dfc43

> The liveness probe is a sidecar container that exposes an HTTP /healthz endpoint, which serves as kubelet's livenessProbe hook to monitor health of a CSI driver.

> The liveness probe uses Probe() call to check the CSI driver is healthy. See CSI spec for more information about Probe API call. Container Storage Interface (CSI)

https://github.com/kubernetes-csi/livenessprobe/tree/master?tab=readme-ov-file#liveness-probe

So `kubelet` basically executes `livenessProbe` which pings the `healthz` endpoint to check if the CSI driver is alive and livenessprobe server forwards that request to the CSI driver's `Probe()` endpoint to check if the driver is healthy. 
https://github.com/kubernetes-csi/livenessprobe/blob/ebd49b57031ab90f6f376f1472884948f381558c/cmd/livenessprobe/main.go#L169 -> https://github.com/kubernetes-csi/livenessprobe/blob/ebd49b57031ab90f6f376f1472884948f381558c/cmd/livenessprobe/main.go#L73

I don't see a need for warm metal to use `hostNetwork` since it doesn't need to access anything on the node. 

warm-metal can access all the unix sockets via `volumeMounts`:
```yaml
...
    volumeMounts:
    - mountPath: /csi
      name: socket-dir
...
    - mountPath: /run/containerd/containerd.sock
      name: runtime-socket
...
  volumes:
  - hostPath:
      path: /var/lib/kubelet/plugins/csi-image.warm-metal.tech
      type: DirectoryOrCreate
    name: socket-dir
...
  - hostPath:
      path: /run/containerd/containerd.sock
      type: Socket
    name: runtime-socket
...
  - name: kube-api-access-xst7n
...
```
ref: https://github.com/warm-metal/csi-driver-image/blob/master/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
