### PR TITLE
fix: Issue with workflow behaviour

### DIFF
--- a/.github/workflows/images-build-and-push.yaml
+++ b/.github/workflows/images-build-and-push.yaml
@@ -6,7 +6,7 @@ on:
     tags:
 
 env:
-  BASE_REPOSITORY: warmmetal/csi-driver-image
+  BASE_REPOSITORY: warm-metal/csi-driver-image
   BASE_DEFAULT_BRANCH: master
   BASE_IMAGE_NAME: warmmetal/csi-image
   FORK_IMAGE_NAME: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
The behaviour mentioned in https://github.com/warm-metal/csi-driver-image/issues/100#issuecomment-1890571298 is not the expected behaviour.

The expected behaviour is, for this repository, all pushes are done to Docker Hub. Any forks will have workflows push to GHCR.

There's a difference between the GitHub Organisation and the Docker Hub Organisation which tripped me up.