### PR TITLE
fix: honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -68,6 +68,17 @@ func main() {
 	if err := flag.Set("logtostderr", "true"); err != nil {
 		panic(err)
 	}
+	// Since kubernetes/klog#432 the legacy behaviour of copying WARNING+
+	// to stderr when logtostderr=true is deprecated. Explicitly request
+	// all severities on stderr so that log output keeps working as before.
+	if err := flag.Set("stderrthreshold", "INFO"); err != nil {
+		panic(err)
+	}
+	// Disable the legacy stderr threshold behaviour so that our explicit
+	// stderrthreshold=INFO takes full effect regardless of klog version.
+	if err := flag.Set("legacy_stderr_threshold_behavior", "false"); err != nil {
+		panic(err)
+	}
 
 	flag.Parse()
 	defer klog.Flush()


### PR DESCRIPTION
## Summary

Since [kubernetes/klog#432](https://github.com/kubernetes/klog/issues/432), klog changed its legacy behavior: when `logtostderr=true` (the default in this driver), WARNING and ERROR messages are **no longer** duplicated to stderr unless you explicitly opt in.

This PR:
- Adds `flag.Set("stderrthreshold", "INFO")` right after the existing `flag.Set("logtostderr", "true")` call, so that all log severities continue to appear on stderr as expected.
- Bumps `k8s.io/klog/v2` from **v2.130.1** to **v2.140.0**.

## Why

Without this fix, users relying on stderr output (e.g. for log aggregation pipelines, `kubectl logs`, or sidecar log collectors) may silently lose WARNING and ERROR messages on stderr.

## Test plan

- [x] `go build ./cmd/plugin/` succeeds
- [ ] Deploy the CSI driver with the updated binary and verify that klog messages at all severities (INFO, WARNING, ERROR) appear on stderr

## References

- https://github.com/kubernetes/klog/issues/432