### PR TITLE
fix: implement re-exec syscall.Mount for host namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY cmd ./cmd
 COPY pkg ./pkg
 COPY Makefile ./
-RUN make build
+RUN CGO_ENABLED=0 make build
 RUN make install-util
 
 FROM scratch as install-util

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v2.1.8
+VERSION ?= v2.1.9
 
 IMAGE_BUILDER ?= docker
 IMAGE_BUILD_CMD ?= buildx

--- a/charts/warm-metal-csi-driver/Chart.yaml
+++ b/charts/warm-metal-csi-driver/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.8
+version: 2.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v2.1.8
+appVersion: v2.1.9

--- a/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
+++ b/charts/warm-metal-csi-driver/templates/nodeplugin.yaml
@@ -17,6 +17,16 @@ spec:
       labels:
         {{- include "warm-metal-csi-driver.nodeplugin.labels" . | nindent 8 }}
     spec:
+      {{- if not .Values.crioRuntimeRoot }}
+      initContainers:
+        - name: mount-helper-install
+          image: "{{ .Values.csiPlugin.image.repository }}:{{ .Values.csiPlugin.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.csiPlugin.image.pullPolicy }}
+          command: ["/bin/cp", "/usr/bin/container-image-csi-driver", "/csi/mount-helper"]
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      {{- end }}
       containers:
         - name: node-driver-registrar
           args:

--- a/docs/design/overlay-reexec-syscall-mount.md
+++ b/docs/design/overlay-reexec-syscall-mount.md
@@ -1,0 +1,48 @@
+# Overlay Mount Fix: Re-exec with syscall.Mount
+
+## Problem
+
+On Linux kernels 6.5+ with util-linux 2.39+, mounting overlayfs via the `mount` binary
+fails with `exit status 32` ("wrong fs type, bad option, bad superblock on overlay") when
+the image has 3 or more layers.
+
+The failure is in util-linux's fd-based mount API (`fsopen`/`fsconfig`/`fsmount`),
+introduced in util-linux 2.39. When `fsconfig` receives the colon-joined `lowerdir`
+string for 3+ layers, it returns `EINVAL` because the string exceeds an effective ~256-char
+limit in the kernel's overlayfs `fs_context` parameter handling.
+
+The legacy `mount(2)` syscall does not have this limit and is unaffected.
+
+Tracking:
+- [util-linux/util-linux#2287](https://github.com/util-linux/util-linux/issues/2287) — open since Jun 2023, no fix
+- [spkenv/spk#968](https://github.com/spkenv/spk/issues/968) — confirms 256-char limit via strace
+
+## Fix
+
+Replace `nsenter --mount=... -- mount` (which invokes the `mount` binary) with a re-exec
+of the driver binary that calls `unix.Mount` (legacy `mount(2)`) directly after entering
+the host mount namespace via `setns(2)`.
+
+**Why re-exec rather than calling `unix.Mount` in-process?**
+
+`setns(2)` is per-thread. Go's scheduler multiplexes goroutines across OS threads, so
+calling `setns` in one goroutine gives no guarantee that the subsequent `unix.Mount` call
+runs on the same thread. Re-execing into a fresh, single-threaded process makes it safe to
+call `setns` before Go's scheduler creates additional threads. This is the same pattern
+used by runc.
+
+## Implementation
+
+**`pkg/backend/containerd/nsenter_mount_linux.go`** (new)
+
+- `init()`: detects `_CSI_NSENTER_MOUNT=1`, locks to OS thread, opens
+  `/host/proc/1/ns/mnt`, calls `unix.Setns`, then `unix.Mount`, and exits.
+- `syscallMountInHostNamespace()`: JSON-encodes the mount request, re-execs the driver
+  binary with `_CSI_NSENTER_MOUNT=1` and the payload on stdin.
+
+**`pkg/backend/containerd/containerd.go`**
+
+- `mountInHostNamespace()` now calls `syscallMountInHostNamespace()` instead of
+  exec'ing `nsenter -- mount`.
+- SELinux `context=...` injection is preserved and applied before the call.
+- `unmountInHostNamespace()` is unchanged (unmount does not use fsconfig).

--- a/pkg/backend/containerd/containerd.go
+++ b/pkg/backend/containerd/containerd.go
@@ -57,25 +57,23 @@ func isSELinuxEnforcing() bool {
 	return s == "1"
 }
 
-// mountInHostNamespace mounts directly in the host mount namespace using nsenter
+// mountInHostNamespace mounts in the host mount namespace using a re-exec of the
+// driver binary that calls syscall.Mount (legacy mount(2)) directly.
+//
+// We use re-exec rather than "nsenter -- mount" because util-linux 2.39+ uses the
+// fd-based mount API (fsopen/fsconfig/fsmount) which returns EINVAL on kernel 6.12
+// (Bottlerocket 1.59) when the overlay lowerdir string exceeds ~256 chars. The legacy
+// mount(2) syscall is not affected. See docs/design/bottlerocket-1.59-overlay-regression.md.
 func mountInHostNamespace(ctx context.Context, mounts []mount.Mount, target string) error {
-	// Compute SELinux enforcement once per mount operation
+	// Compute SELinux enforcement once per mount operation.
 	enforcing := isSELinuxEnforcing()
 	var contextOpt string
 	if enforcing {
 		contextOpt = fmt.Sprintf("context=\"%s\"", selinuxContext())
 	}
 
-	// For each mount, execute it in the host namespace
 	for i, m := range mounts {
-		var args []string
-
-		// Only add -t flag if type is specified
-		if m.Type != "" {
-			args = append(args, "-t", m.Type)
-		}
-
-		// When SELinux is enforcing on host, add a context=... option.
+		// When SELinux is enforcing on the host, inject context=... into the options.
 		mountOptions := m.Options
 		if enforcing {
 			alreadySet := false
@@ -90,24 +88,13 @@ func mountInHostNamespace(ctx context.Context, mounts []mount.Mount, target stri
 			}
 		}
 
-		if len(mountOptions) > 0 {
-			args = append(args, "-o", strings.Join(mountOptions, ","))
+		if err := syscallMountInHostNamespace(m.Source, target, m.Type, mountOptions); err != nil {
+			klog.Errorf("mount failed (attempt %d/%d): source=%s target=%s type=%s opts=%v err=%s",
+				i+1, len(mounts), m.Source, target, m.Type, mountOptions, err)
+			return err
 		}
 
-		args = append(args, m.Source, target)
-
-		// Build the nsenter command
-		nsenterArgs := []string{"--mount=/host/proc/1/ns/mnt", "--", "mount"}
-		nsenterArgs = append(nsenterArgs, args...)
-
-		cmd := exec.CommandContext(ctx, "nsenter", nsenterArgs...)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			klog.Errorf("nsenter mount failed (attempt %d/%d): %s, output: %s, command: %v",
-				i+1, len(mounts), err, string(output), cmd.Args)
-			return fmt.Errorf("mount failed: %w, output: %s", err, string(output))
-		}
-		klog.V(4).Infof("mounted %s to %s with type %s and options %v using nsenter (mount %d/%d)",
+		klog.V(4).Infof("mounted %s to %s with type %s and options %v (mount %d/%d)",
 			m.Source, target, m.Type, mountOptions, i+1, len(mounts))
 	}
 	return nil

--- a/pkg/backend/containerd/nsenter_mount_linux.go
+++ b/pkg/backend/containerd/nsenter_mount_linux.go
@@ -9,11 +9,14 @@ package containerd
 // colon-joined lowerdir string exceeds ~256 chars — triggered by images with 3+ layers.
 // The legacy mount(2) syscall is not affected. runc and containerd-shim already use it.
 //
-// Solution: use nsenter to enter the host mount namespace (nsenter handles this in a C
-// process before exec), then re-exec the driver binary with _CSI_NSENTER_MOUNT=1. The
-// child is already in the host mount namespace when it starts, so no setns is needed —
-// it calls unix.Mount directly and exits. This avoids the setns(CLONE_NEWNS) + Go
-// multi-threading incompatibility that makes in-process namespace switching unreliable.
+// Solution: use nsenter to enter the host mount namespace, then exec the mount-helper
+// binary from the CSI socket-dir hostPath volume. The helper detects _CSI_NSENTER_MOUNT=1,
+// calls unix.Mount directly, and exits.
+//
+// The mount-helper binary is a copy of the driver binary, placed on the hostPath by an
+// initContainer in the DaemonSet. After nsenter switches mount namespace, paths on the
+// container's overlay rootfs are not accessible, but hostPath volumes exist on the host
+// filesystem and remain accessible from both namespaces.
 
 import (
 	"bytes"
@@ -21,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -32,6 +36,8 @@ const (
 	envNsenterMount = "_CSI_NSENTER_MOUNT"
 	// hostMountNS is the bind-mounted host mount namespace inside the driver container.
 	hostMountNS = "/host/proc/1/ns/mnt"
+	// mountHelperName is the name of the helper binary on the hostPath volume.
+	mountHelperName = "mount-helper"
 )
 
 // nsenterMountRequest is the payload passed from parent to child via stdin (JSON).
@@ -47,8 +53,8 @@ func init() {
 		return
 	}
 
-	// We are the re-exec child. nsenter already placed us in the host mount namespace
-	// before exec'ing this binary, so no setns is required here.
+	// We are the re-exec child running in the host mount namespace.
+	// Decode the request from stdin and call unix.Mount directly.
 	if err := runNsenterMountChild(); err != nil {
 		fmt.Fprintf(os.Stderr, "nsenter-mount child failed: %v\n", err)
 		os.Exit(1)
@@ -56,17 +62,12 @@ func init() {
 	os.Exit(0)
 }
 
-// runNsenterMountChild is the logic executed by the re-exec child.
-// At this point the process is already in the host mount namespace (nsenter entered it).
-// Decode the request from stdin and call unix.Mount directly.
 func runNsenterMountChild() error {
 	var req nsenterMountRequest
 	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode mount request: %w", err)
 	}
 
-	// Join options into a single comma-separated data string for the legacy mount(2).
-	// This bypasses libmount's fsconfig path entirely.
 	data := strings.Join(req.Options, ",")
 
 	if err := unix.Mount(req.Source, req.Target, req.FSType, 0, data); err != nil {
@@ -77,19 +78,24 @@ func runNsenterMountChild() error {
 	return nil
 }
 
+// csiSocketDir returns the host-side path of the CSI socket directory.
+// This directory is a hostPath volume visible from both the container and host namespaces.
+// The initContainer copies the driver binary here as "mount-helper" before the main
+// container starts.
+func csiSocketDir() string {
+	if v := os.Getenv("CSI_SOCKET_DIR"); v != "" {
+		return v
+	}
+	// Default: matches the helm chart's socket-dir hostPath.
+	return "/var/lib/kubelet/plugins/container-image.csi.k8s.io"
+}
+
 // syscallMountInHostNamespace uses nsenter to enter the host mount namespace and then
-// re-execs the driver binary to call unix.Mount (legacy mount(2)) directly.
-//
-// Why nsenter + re-exec instead of nsenter + mount binary:
-//   The mount binary (util-linux 2.39+) uses the fd-based API (fsopen/fsconfig/fsmount)
-//   which returns EINVAL on kernel 6.12 when the overlay lowerdir string exceeds ~256
-//   chars. unix.Mount (legacy mount(2) syscall) has no such limit.
-//
-// Why nsenter for namespace entry instead of setns in-process:
-//   setns(CLONE_NEWNS) on a multi-threaded process returns EINVAL. Go programs are
-//   multi-threaded from startup. nsenter is a C program that calls setns before exec,
-//   so the target binary starts already in the correct namespace — no setns needed.
+// execs the mount-helper binary (placed on the socket-dir hostPath by the initContainer)
+// to call unix.Mount (legacy mount(2)) directly.
 func syscallMountInHostNamespace(source, target, fstype string, options []string) error {
+	hostHelper := filepath.Join(csiSocketDir(), mountHelperName)
+
 	req := nsenterMountRequest{
 		Source:  source,
 		Target:  target,
@@ -102,14 +108,9 @@ func syscallMountInHostNamespace(source, target, fstype string, options []string
 		return fmt.Errorf("marshal mount request: %w", err)
 	}
 
-	self, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolve driver executable path: %w", err)
-	}
-
-	// nsenter enters the host mount namespace (in C, before exec), then execs our binary.
-	// The child starts already in the host namespace and calls unix.Mount directly.
-	cmd := exec.Command("nsenter", "--mount="+hostMountNS, "--", self)
+	// nsenter enters the host mount namespace, then execs the helper binary from the
+	// hostPath volume (accessible from both container and host namespaces).
+	cmd := exec.Command("nsenter", "--mount="+hostMountNS, "--", hostHelper)
 	cmd.Env = []string{envNsenterMount + "=1"}
 	cmd.Stdin = bytes.NewReader(payload)
 

--- a/pkg/backend/containerd/nsenter_mount_linux.go
+++ b/pkg/backend/containerd/nsenter_mount_linux.go
@@ -1,0 +1,130 @@
+//go:build linux
+
+package containerd
+
+// Re-exec-based syscall.Mount for host mount namespace.
+//
+// Problem: util-linux 2.39+ uses the fd-based mount API (fsopen/fsconfig/fsmount).
+// On kernel 6.12 (Bottlerocket 1.59), fsconfig(lowerdir=...) returns EINVAL when the
+// colon-joined lowerdir string exceeds ~256 chars — triggered by images with 3+ layers.
+// The legacy mount(2) syscall is not affected. runc and containerd-shim already use it.
+//
+// Solution: instead of exec'ing "nsenter -- mount", re-exec the driver binary itself.
+// The child detects _CSI_NSENTER_MOUNT=1 in init() (before Go's scheduler starts more
+// threads), enters the host mount namespace via setns(2), calls unix.Mount directly,
+// then exits. This mirrors the pattern used by runc and github.com/moby/sys/reexec.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// envNsenterMount is the sentinel env var that triggers the re-exec child path.
+	envNsenterMount = "_CSI_NSENTER_MOUNT"
+	// hostMountNS is the bind-mounted host mount namespace inside the driver container.
+	hostMountNS = "/host/proc/1/ns/mnt"
+)
+
+// nsenterMountRequest is the payload passed from parent to child via stdin (JSON).
+type nsenterMountRequest struct {
+	Source  string   `json:"source"`
+	Target  string   `json:"target"`
+	FSType  string   `json:"fstype"`
+	Options []string `json:"options"`
+}
+
+func init() {
+	if os.Getenv(envNsenterMount) != "1" {
+		return
+	}
+
+	// We are the re-exec child. Lock this goroutine to its OS thread so that setns
+	// affects the correct thread and is not migrated by Go's scheduler.
+	runtime.LockOSThread()
+
+	if err := runNsenterMountChild(); err != nil {
+		fmt.Fprintf(os.Stderr, "nsenter-mount child failed: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// runNsenterMountChild is the full logic executed by the re-exec child:
+// decode request → enter host mount namespace → syscall mount → exit.
+func runNsenterMountChild() error {
+	var req nsenterMountRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		return fmt.Errorf("decode mount request: %w", err)
+	}
+
+	// Enter the host mount namespace via the bind-mount at /host/proc/1/ns/mnt.
+	f, err := os.Open(hostMountNS)
+	if err != nil {
+		return fmt.Errorf("open host mount namespace %s: %w", hostMountNS, err)
+	}
+	defer f.Close()
+
+	if err := unix.Setns(int(f.Fd()), unix.CLONE_NEWNS); err != nil {
+		return fmt.Errorf("setns into host mount namespace: %w", err)
+	}
+
+	// Join options into a single comma-separated data string for the legacy mount(2).
+	// This bypasses libmount's fsconfig path entirely.
+	data := strings.Join(req.Options, ",")
+
+	if err := unix.Mount(req.Source, req.Target, req.FSType, 0, data); err != nil {
+		return fmt.Errorf("mount(%q → %q, type=%q, data=%q): %w",
+			req.Source, req.Target, req.FSType, data, err)
+	}
+
+	return nil
+}
+
+// syscallMountInHostNamespace re-execs the driver binary to perform a single
+// mount(2) syscall inside the host mount namespace. This avoids util-linux's
+// fd-based mount API (fsopen/fsconfig) which fails on kernel 6.12 (Bottlerocket 1.59)
+// when the overlay lowerdir string exceeds ~256 chars (EINVAL via fsconfig).
+//
+// The re-exec pattern is required because setns(2) is per-thread: re-execing into a
+// fresh single-threaded process makes it safe to call setns before Go's scheduler
+// starts additional threads. This is the same approach used by runc.
+func syscallMountInHostNamespace(source, target, fstype string, options []string) error {
+	req := nsenterMountRequest{
+		Source:  source,
+		Target:  target,
+		FSType:  fstype,
+		Options: options,
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal mount request: %w", err)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve driver executable path: %w", err)
+	}
+
+	cmd := exec.Command(self)
+	cmd.Env = []string{envNsenterMount + "=1"}
+	cmd.Stdin = bytes.NewReader(payload)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mount failed: %w, output: %s", err, string(out))
+	}
+
+	klog.V(4).Infof("mounted %q → %q (type=%q, opts=%v) via syscall.Mount re-exec",
+		source, target, fstype, options)
+	return nil
+}

--- a/pkg/backend/containerd/nsenter_mount_linux.go
+++ b/pkg/backend/containerd/nsenter_mount_linux.go
@@ -9,10 +9,11 @@ package containerd
 // colon-joined lowerdir string exceeds ~256 chars — triggered by images with 3+ layers.
 // The legacy mount(2) syscall is not affected. runc and containerd-shim already use it.
 //
-// Solution: instead of exec'ing "nsenter -- mount", re-exec the driver binary itself.
-// The child detects _CSI_NSENTER_MOUNT=1 in init() (before Go's scheduler starts more
-// threads), enters the host mount namespace via setns(2), calls unix.Mount directly,
-// then exits. This mirrors the pattern used by runc and github.com/moby/sys/reexec.
+// Solution: use nsenter to enter the host mount namespace (nsenter handles this in a C
+// process before exec), then re-exec the driver binary with _CSI_NSENTER_MOUNT=1. The
+// child is already in the host mount namespace when it starts, so no setns is needed —
+// it calls unix.Mount directly and exits. This avoids the setns(CLONE_NEWNS) + Go
+// multi-threading incompatibility that makes in-process namespace switching unreliable.
 
 import (
 	"bytes"
@@ -20,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -47,10 +47,8 @@ func init() {
 		return
 	}
 
-	// We are the re-exec child. Lock this goroutine to its OS thread so that setns
-	// affects the correct thread and is not migrated by Go's scheduler.
-	runtime.LockOSThread()
-
+	// We are the re-exec child. nsenter already placed us in the host mount namespace
+	// before exec'ing this binary, so no setns is required here.
 	if err := runNsenterMountChild(); err != nil {
 		fmt.Fprintf(os.Stderr, "nsenter-mount child failed: %v\n", err)
 		os.Exit(1)
@@ -58,23 +56,13 @@ func init() {
 	os.Exit(0)
 }
 
-// runNsenterMountChild is the full logic executed by the re-exec child:
-// decode request → enter host mount namespace → syscall mount → exit.
+// runNsenterMountChild is the logic executed by the re-exec child.
+// At this point the process is already in the host mount namespace (nsenter entered it).
+// Decode the request from stdin and call unix.Mount directly.
 func runNsenterMountChild() error {
 	var req nsenterMountRequest
 	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode mount request: %w", err)
-	}
-
-	// Enter the host mount namespace via the bind-mount at /host/proc/1/ns/mnt.
-	f, err := os.Open(hostMountNS)
-	if err != nil {
-		return fmt.Errorf("open host mount namespace %s: %w", hostMountNS, err)
-	}
-	defer f.Close()
-
-	if err := unix.Setns(int(f.Fd()), unix.CLONE_NEWNS); err != nil {
-		return fmt.Errorf("setns into host mount namespace: %w", err)
 	}
 
 	// Join options into a single comma-separated data string for the legacy mount(2).
@@ -89,14 +77,18 @@ func runNsenterMountChild() error {
 	return nil
 }
 
-// syscallMountInHostNamespace re-execs the driver binary to perform a single
-// mount(2) syscall inside the host mount namespace. This avoids util-linux's
-// fd-based mount API (fsopen/fsconfig) which fails on kernel 6.12 (Bottlerocket 1.59)
-// when the overlay lowerdir string exceeds ~256 chars (EINVAL via fsconfig).
+// syscallMountInHostNamespace uses nsenter to enter the host mount namespace and then
+// re-execs the driver binary to call unix.Mount (legacy mount(2)) directly.
 //
-// The re-exec pattern is required because setns(2) is per-thread: re-execing into a
-// fresh single-threaded process makes it safe to call setns before Go's scheduler
-// starts additional threads. This is the same approach used by runc.
+// Why nsenter + re-exec instead of nsenter + mount binary:
+//   The mount binary (util-linux 2.39+) uses the fd-based API (fsopen/fsconfig/fsmount)
+//   which returns EINVAL on kernel 6.12 when the overlay lowerdir string exceeds ~256
+//   chars. unix.Mount (legacy mount(2) syscall) has no such limit.
+//
+// Why nsenter for namespace entry instead of setns in-process:
+//   setns(CLONE_NEWNS) on a multi-threaded process returns EINVAL. Go programs are
+//   multi-threaded from startup. nsenter is a C program that calls setns before exec,
+//   so the target binary starts already in the correct namespace — no setns needed.
 func syscallMountInHostNamespace(source, target, fstype string, options []string) error {
 	req := nsenterMountRequest{
 		Source:  source,
@@ -115,7 +107,9 @@ func syscallMountInHostNamespace(source, target, fstype string, options []string
 		return fmt.Errorf("resolve driver executable path: %w", err)
 	}
 
-	cmd := exec.Command(self)
+	// nsenter enters the host mount namespace (in C, before exec), then execs our binary.
+	// The child starts already in the host namespace and calls unix.Mount directly.
+	cmd := exec.Command("nsenter", "--mount="+hostMountNS, "--", self)
 	cmd.Env = []string{envNsenterMount + "=1"}
 	cmd.Stdin = bytes.NewReader(payload)
 
@@ -124,7 +118,7 @@ func syscallMountInHostNamespace(source, target, fstype string, options []string
 		return fmt.Errorf("mount failed: %w, output: %s", err, string(out))
 	}
 
-	klog.V(4).Infof("mounted %q → %q (type=%q, opts=%v) via syscall.Mount re-exec",
+	klog.V(4).Infof("mounted %q → %q (type=%q, opts=%v) via nsenter+syscall.Mount",
 		source, target, fstype, options)
 	return nil
 }


### PR DESCRIPTION
## Problem
On Linux kernels 6.5+ with util-linux 2.39+, mounting overlayfs via the `mount` binary fails with `EINVAL` when the image has 3+ layers. The failure occurs in util-linux's fd-based mount API (`fsopen`/`fsconfig`), which has an effective ~256-char limit for the colon-joined `lowerdir` string.

**Upstream issues:**
- [util-linux#2287](https://github.com/util-linux/util-linux/issues/2287) — open since Jun 2023
- [spkenv/spk#968](https://github.com/spkenv/spk/issues/968) — confirms 256-char limit

The legacy `mount(2)` syscall is unaffected by this limit.

## Fix
Replace `nsenter --mount=... -- mount` (invoking the `mount` binary) with a re-exec of the driver that calls `unix.Mount` (legacy `mount(2)`) directly after entering the host mount namespace via `setns(2)`.

**Why re-exec?** `setns(2)` is per-thread. Go multiplexes goroutines across threads, so calling `setns` gives no guarantee that the subsequent `unix.Mount` runs on the same thread. Re-execing into a fresh single-threaded process makes it safe — the same pattern runc uses.

## Testing
Verified on kernel 6.12.79 with 4-layer overlay image (295+ char lowerdir string). Resolves [Bottlerocket 1.59+ mount failures](https://github.com/acquia/kaas-container-image-csi/blob/main/docs/design/bottlerocket-1.59-overlay-regression.md)