### PR TITLE
ci: auto-fix branch-specific workflow divergences during backport

### DIFF
--- a/.github/workflows/images-build-and-push.yaml
+++ b/.github/workflows/images-build-and-push.yaml
@@ -221,7 +221,18 @@ jobs:
           sed -i "s/^version: .*/version: ${CHART_VERSION}/" charts/warm-metal-csi-driver/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: ${NEW_V1_TAG}/" charts/warm-metal-csi-driver/Chart.yaml
 
-          git add Makefile charts/warm-metal-csi-driver/Chart.yaml
+          # Fix workflow-level branch-specific divergences unconditionally. These lines
+          # often conflict because v2.x and v1.2.x intentionally differ.
+          BASE_IMAGE_NAME_COND="${{ (startsWith(github.ref, 'refs/tags/v1.') || github.ref == 'refs/heads/release-v1.2.x') && 'warmmetal/csi-image' || 'warmmetal/container-image-csi-driver' }}"
+          sed -i "s|^  BASE_IMAGE_NAME:.*|  BASE_IMAGE_NAME: ${BASE_IMAGE_NAME_COND}|" .github/workflows/images-build-and-push.yaml
+
+          # Ensure the backported release is never promoted to GitHub's "Latest".
+          # If the line already ends with --latest=false, leave it unchanged.
+          if ! grep -q '^            --latest=false$' .github/workflows/images-build-and-push.yaml; then
+            sed -i '/^            --target release-v1\.2\.x$/a\\            --latest=false' .github/workflows/images-build-and-push.yaml
+          fi
+
+          git add Makefile charts/warm-metal-csi-driver/Chart.yaml .github/workflows/images-build-and-push.yaml
 
           # Amend the last cherry-pick commit to include the version fixups,
           # then soft-reset all cherry-picked commits into one squash commit


### PR DESCRIPTION
The backport-release job cherry-picks commits from a v2.x tag range onto release-v1.2.x. Two workflow lines always conflict or diverge between the branches:

1. BASE_IMAGE_NAME: v2.x uses warmmetal/container-image-csi-driver, while v1.2.x releases must publish to warmmetal/csi-image.
2. gh release create: v1.2.x releases must pass --latest=false so GitHub does not promote the older maintenance release over the current v2.x release.

Instead of relying on the cherry-pick to resolve these correctly, apply them unconditionally after the cherry-pick loop. This prevents the backport job from failing on merge conflicts for these known per-branch differences.